### PR TITLE
Move coverage setup to initializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ end
 
 group :development, :test do
   gem 'solr_wrapper', '>= 0.3'
-  gem 'coveralls', require: false
   gem 'simplecov', '~> 0.9', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,12 +80,6 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
-    coveralls (0.8.13)
-      json (~> 1.8)
-      simplecov (~> 0.11.0)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-      tins (~> 1.6.0)
     debug_inspector (0.0.2)
     deprecation (1.0.0)
       activesupport
@@ -231,12 +225,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
-    term-ansicolor (1.3.2)
-      tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
-    tins (1.6.0)
     traject (2.3.1)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
@@ -280,7 +271,6 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.1.0)
-  coveralls
   devise
   devise-guests (~> 0.3)
   jbuilder (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Stories in Ready](https://badge.waffle.io/pulibrary/cicognara-rails.png?label=ready&title=Ready)](https://waffle.io/pulibrary/cicognara-rails)
-[![Coverage Status](https://coveralls.io/repos/github/pulibrary/cicognara-rails/badge.svg)](https://coveralls.io/github/pulibrary/cicognara-rails)
 
 # cicognara-rails
 Rails app for managing metadata for the Digital Cicogara Library

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,6 @@ RuboCop::RakeTask.new(:rubocop) do |task|
 end
 
 task :ci do
-  require 'coveralls/rake/task'
   SolrWrapper.wrap(port: 8888) do |solr|
     solr.with_collection(name: 'cicognara', dir: File.join(File.expand_path(File.dirname(__FILE__)), 'solr', 'config')) do
       Rake::Task['spec'].invoke

--- a/config/initializers/0_coverage.rb
+++ b/config/initializers/0_coverage.rb
@@ -1,0 +1,9 @@
+if Rails.env.test?
+  require 'simplecov'
+  if ENV['CIRCLE_ARTIFACTS']
+    SimpleCov.coverage_dir(File.join(ENV['CIRCLE_ARTIFACTS'], 'coverage'))
+  end
+  SimpleCov.start('rails') do
+    add_filter '/spec'
+  end
+end

--- a/spec/cicognara/tei_indexer_spec.rb
+++ b/spec/cicognara/tei_indexer_spec.rb
@@ -1,5 +1,5 @@
-require 'tei_helper'
 require 'rails_helper'
+require 'tei_helper'
 
 describe TEIIndexer do
   subject { described_class.new(pathtotei) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,15 +16,6 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'simplecov'
-if ENV['CI']
-  require 'coveralls'
-  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-end
-SimpleCov.start('rails') do
-  add_filter '/spec'
-end
-
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
* Initializer runs before User model is used in other initializers
* Removing Coveralls integration because it isn't working
* Coverage is reported in CircleCI build and report is available in the Circle Artifiacts, e.g.: https://circle-artifacts.com/gh/pulibrary/cicognara-rails/68/artifacts/0/tmp/circle-artifacts.Zi5ovJ8/coverage/index.html