### PR TITLE
Index marc

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -67,21 +67,11 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'format', label: 'Format'
     config.add_facet_field 'pub_date', label: 'Publication Year', single: true
     config.add_facet_field 'subject_topic_facet', label: 'Topic', limit: 20, index_range: 'A'..'Z'
     config.add_facet_field 'language_facet', label: 'Language', limit: true
-    config.add_facet_field 'lc_1letter_facet', label: 'Call Number'
     config.add_facet_field 'subject_geo_facet', label: 'Region'
     config.add_facet_field 'subject_era_facet', label: 'Era'
-
-    config.add_facet_field 'example_pivot_field', label: 'Pivot Field', pivot: %w(format language_facet)
-
-    config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {
-      years_5: { label: 'within 5 Years', fq: "pub_date:[#{Time.zone.now.year - 5} TO *]" },
-      years_10: { label: 'within 10 Years', fq: "pub_date:[#{Time.zone.now.year - 10} TO *]" },
-      years_25: { label: 'within 25 Years', fq: "pub_date:[#{Time.zone.now.year - 25} TO *]" }
-    }
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -91,33 +81,23 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field 'title_display', label: 'Title'
-    config.add_index_field 'title_vern_display', label: 'Title'
     config.add_index_field 'author_display', label: 'Author'
-    config.add_index_field 'author_vern_display', label: 'Author'
-    config.add_index_field 'format', label: 'Format'
     config.add_index_field 'language_facet', label: 'Language'
-    config.add_index_field 'published_display', label: 'Published'
-    config.add_index_field 'published_vern_display', label: 'Published'
-    config.add_index_field 'lc_callnum_display', label: 'Call number'
+    config.add_index_field 'published_t', label: 'Published'
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field 'title_display', label: 'Title'
-    config.add_show_field 'title_vern_display', label: 'Title'
-    config.add_show_field 'subtitle_display', label: 'Subtitle'
-    config.add_show_field 'subtitle_vern_display', label: 'Subtitle'
     config.add_show_field 'author_display', label: 'Author'
-    config.add_show_field 'author_vern_display', label: 'Author'
-    config.add_show_field 'format', label: 'Format'
-    config.add_show_field 'url_fulltext_display', label: 'URL'
-    config.add_show_field 'url_suppl_display', label: 'More Information'
     config.add_show_field 'language_facet', label: 'Language'
-    config.add_show_field 'published_display', label: 'Published'
-    config.add_show_field 'published_vern_display', label: 'Published'
-    config.add_show_field 'lc_callnum_display', label: 'Call number'
-    config.add_show_field 'isbn_t', label: 'ISBN'
+    config.add_show_field 'published_t', label: 'Published'
     config.add_show_field 'cico_s', label: 'Cicognara number'
     config.add_show_field 'dclib_s', label: 'DCL id(s)'
+    config.add_show_field 'title_addl_t', label: 'Other title(s)'
+    config.add_show_field 'title_added_entry_t', label: 'Added entry title(s)'
+    config.add_show_field 'title_series_t', label: 'Series'
+    config.add_show_field 'subject_t', label: 'Subject'
+    config.add_show_field 'contents_t', label: 'Contents'
+    config.add_show_field 'edition_t', label: 'Edition'
     config.add_show_field 'description_t', label: 'Catalogo entry'
 
     # "fielded" search configuration. Used by pulldown among other places.
@@ -182,10 +162,10 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, pub_date_sort desc, title_sort asc', label: 'relevance'
+    config.add_sort_field 'score desc, title_sort asc', label: 'relevance'
     config.add_sort_field 'pub_date_sort desc, title_sort asc', label: 'year'
     config.add_sort_field 'author_sort asc, title_sort asc', label: 'author'
-    config.add_sort_field 'title_sort asc, pub_date_sort desc', label: 'title'
+    config.add_sort_field 'title_sort asc', label: 'title'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/models/marc_indexer.rb
+++ b/app/models/marc_indexer.rb
@@ -3,6 +3,50 @@ class MarcIndexer < Blacklight::Marc::Indexer
   # this mixin defines lambda facotry method get_format for legacy marc formats
   include Blacklight::Marc::Indexer::Formats
 
+  SEPARATOR = '—'
+
+  GENRES = [
+  'Bibliography',
+  'Biography',
+  'Catalogs',
+  'Catalogues raisonnes',
+  'Commentaries',
+  'Congresses',
+  'Diaries',
+  'Dictionaries',
+  'Drama',
+  'Encyclopedias',
+  'Exhibitions',
+  'Fiction',
+  'Guidebooks',
+  'In art',
+  'Indexes',
+  'Librettos',
+  'Manuscripts',
+  'Newspapers',
+  'Periodicals',
+  'Pictorial works',
+  'Poetry',
+  'Portraits',
+  'Scores',
+  'Songs and music',
+  'Sources',
+  'Statistics',
+  'Texts',
+  'Translations'
+  ]
+
+  GENRE_STARTS_WITH = [
+    'Census',
+    'Maps',
+    'Methods',
+    'Parts',
+    'Personal narratives',
+    'Scores and parts',
+    'Study and teaching',
+    'Translations into '
+  ]
+
   def initialize
     super
 
@@ -13,36 +57,31 @@ class MarcIndexer < Blacklight::Marc::Indexer
       provide 'solr_writer.max_skipped', -1
     end
 
-    to_field 'id', trim(extract_marc('001'), first: true)
+    to_field 'id' do |record, accumulator|
+      ids = []
+      Traject::MarcExtractor.cached('024a').collect_matching_lines(record) do |field, spec, extractor|
+        id = extractor.collect_subfields(field, spec).first
+        unless id.nil?
+          field.subfields.each do |s_field|
+            ids << id if (s_field.code == '2') and s_field.value == 'dclib'
+          end
+        end
+      end
+      accumulator.replace(ids.uniq)
+    end
+
     to_field 'marc_display', get_xml
     to_field 'text', extract_all_marc_values do |_r, acc|
       acc.replace [acc.join(' ')] # turn it into a single string
     end
 
-    to_field 'language_facet', marc_languages('008[35-37]:041a:041d:')
-    to_field 'format', get_format
-    to_field 'isbn_t',  extract_marc('020a', separator: nil) do |_rec, acc|
-      orig = acc.dup
-      acc.map! { |x| StdNum::ISBN.allNormalizedValues(x) }
-      acc << orig
-      acc.flatten!
-      acc.uniq!
-    end
-
-    to_field 'material_type_display', extract_marc('300a', trim_punctuation: true)
+    to_field 'language_facet', marc_languages('008[35-37]:041a:041d')
 
     # Title fields
     #    primary title
 
-    to_field 'title_t', extract_marc('245a')
-    to_field 'title_display', extract_marc('245a', trim_punctuation: true, alternate_script: false)
-    to_field 'title_vern_display', extract_marc('245a', trim_punctuation: true, alternate_script: :only)
-
-    #    subtitle
-
-    to_field 'subtitle_t', extract_marc('245b')
-    to_field 'subtitle_display', extract_marc('245b', trim_punctuation: true, alternate_script: false)
-    to_field 'subtitle_vern_display', extract_marc('245b', trim_punctuation: true, alternate_script: :only)
+    to_field 'title_t', extract_marc('245abchknps')
+    to_field 'title_display', extract_marc('245abcfghknps', trim_punctuation: true, alternate_script: false)
 
     #    additional title fields
     to_field 'title_addl_t',
@@ -68,94 +107,107 @@ class MarcIndexer < Blacklight::Marc::Indexer
 
     to_field 'title_series_t', extract_marc('440anpv:490av')
 
-    to_field 'title_sort', marc_sortable_title
+    to_field 'title_sort' do |record, accumulator|
+      MarcExtractor.cached("245abcfghknps", :alternate_script => false).collect_matching_lines(record) do |field, spec, extractor|
+        str = extractor.collect_subfields(field, spec).first
+        str = str.slice(field.indicator2.to_i, str.length) if str
+        accumulator << str if accumulator[0].nil?
+      end
+    end
 
     # Author fields
 
-    to_field 'author_t', extract_marc('100abcegqu:110abcdegnu:111acdegjnqu')
-    to_field 'author_addl_t', extract_marc('700abcegqu:710abcdegnu:711acdegjnqu')
-    to_field 'author_display', extract_marc("100abcdq:110#{ATOZ}:111#{ATOZ}", alternate_script: false)
-    to_field 'author_vern_display', extract_marc("100abcdq:110#{ATOZ}:111#{ATOZ}", alternate_script: :only)
-
-    # JSTOR isn't an author. Try to not use it as one
-    to_field 'author_sort', marc_sortable_author
+    to_field 'author_t', extract_marc('100aqbcdk:110abcdfgkln:111abcdfgklnpq:700aqbcdk:710abcdfgkln:711abcdfgklnpq', trim_punctuation: true)
+    to_field 'author_display', extract_marc('100aqbcdk:110abcdfgkln:111abcdfgklnpq', trim_punctuation: true)
+    to_field 'author_sort', extract_marc('100aqbcdk:110abcdfgkln:111abcdfgklnpq', trim_punctuation: true, first: true)
 
     # Subject fields
-    to_field 'subject_t', extract_marc(%W(
-      600#{ATOU}
-      610#{ATOU}
-      611#{ATOU}
-      630#{ATOU}
-      650abcde
-      651ae
-      653a:654abcde:655abc
-    ).join(':'))
-    to_field 'subject_addl_t', extract_marc('600vwxyz:610vwxyz:611vwxyz:630vwxyz:650vwxyz:651vwxyz:654vwxyz:655vwxyz')
-    to_field 'subject_topic_facet', extract_marc('600abcdq:610ab:611ab:630aa:650aa:653aa:654ab:655ab', trim_punctuation: true)
-    to_field 'subject_era_facet',  extract_marc('650y:651y:654y:655y', trim_punctuation: true)
-    to_field 'subject_geo_facet',  extract_marc('651a:650z', trim_punctuation: true)
+    to_field 'subject_t' do |record, accumulator|
+      subjects = []
+      Traject::MarcExtractor.cached(%w(
+        600|*0|abcdfklmnopqrtvxyz:
+        610|*0|abfklmnoprstvxyz:
+        611|*0|abcdefgklnpqstvxyz:
+        630|*0|adfgklmnoprstvxyz:
+        650|*0|abcvxyz:
+        651|*0|avxyz
+      )).collect_matching_lines(record) do |field, spec, extractor|
+        subject = extractor.collect_subfields(field, spec).first
+        unless subject.nil?
+          field.subfields.each do |s_field|
+            if (s_field.code == 'v' || s_field.code == 'x' || s_field.code == 'y' || s_field.code == 'z')
+              subject = subject.gsub(" #{s_field.value}", "#{SEPARATOR}#{s_field.value}")
+            end
+          end
+          subjects << Traject::Macros::Marc21.trim_punctuation(subject)
+        end
+      end
+      accumulator.replace(subjects)
+    end
+
+    to_field 'subject_topic_facet' do |record, accumulator|
+      subjects = []
+      Traject::MarcExtractor.cached(%w(
+        600|*0|abcdfklmnopqrtxz:
+        610|*0|abfklmnoprstxz:
+        611|*0|abcdefgklnpqstxz:
+        630|*0|adfgklmnoprstxz:
+        650|*0|abcxz:
+        651|*0|axz
+      )).collect_matching_lines(record) do |field, spec, extractor|
+        subject = extractor.collect_subfields(field, spec).first
+        unless subject.nil?
+          field.subfields.each do |s_field|
+            if (s_field.code == 'x' || s_field.code == 'z')
+              subject = subject.gsub(" #{s_field.value}", "#{SEPARATOR}#{s_field.value}")
+            end
+          end
+          subject = subject.split(SEPARATOR)
+          subjects << subject.map { |s| Traject::Macros::Marc21.trim_punctuation(s) }
+        end
+      end
+      accumulator.replace(subjects.flatten.uniq)
+    end
+
+    # 600/610/650/651 $v, $x filtered
+    # 655 $a, $v, $x filtered
+    to_field 'subject_genre_facet' do |record, accumulator|
+      genres = []
+      Traject::MarcExtractor.cached(%w(
+        600|*0|x:610|*0|x:611|*0|x:
+        630|*0|x:650|*0|x:651|*0|x:655|*0|x
+      )).collect_matching_lines(record) do |field, spec, extractor|
+        genre = extractor.collect_subfields(field, spec).first
+        unless genre.nil?
+          genre = Traject::Macros::Marc21.trim_punctuation(genre)
+          genres << genre if GENRES.include?(genre) || GENRE_STARTS_WITH.any? { |g| genre[g] }
+        end
+      end
+      Traject::MarcExtractor.cached(%w(
+        600|*0|v:610|*0|v:611|*0|v:
+        630|*0|v:650|*0|v:651|*0|v:
+        655|*0|a:655|*0|v
+      )).collect_matching_lines(record) do |field, spec, extractor|
+        genre = extractor.collect_subfields(field, spec).first
+        unless genre.nil?
+          genre = Traject::Macros::Marc21.trim_punctuation(genre)
+          genres << genre
+        end
+      end
+      accumulator.replace(genres.uniq)
+    end
+
+    to_field 'subject_era_facet', marc_era_facet
+    to_field 'subject_geo_facet', extract_marc('651a:650z', trim_punctuation: true)
 
     # Publication fields
-    to_field 'published_display', extract_marc('260a', trim_punctuation: true, alternate_script: false)
-    to_field 'published_vern_display', extract_marc('260a', trim_punctuation: true, alternate_script: :only)
+    to_field 'published_t', extract_marc('260abcefg:264abcefg')
     to_field 'pub_date', marc_publication_date
 
-    # Call Number fields
-    to_field 'lc_callnum_display', extract_marc('050ab', first: true)
-    to_field 'lc_1letter_facet', extract_marc('050ab', first: true, translation_map: 'callnumber_map') do |_rec, acc|
-      # Just get the first letter to send to the translation map
-      acc.map! { |x| x[0] }
-    end
+    # Analytics
+    to_field 'contents_t', extract_marc('505|0*|agrt:505|8*|agrt')
 
-    alpha_pat = /\A([A-Z]{1,3})\d.*\Z/
-    to_field 'lc_alpha_facet', extract_marc('050a', first: true) do |_rec, acc|
-      acc.map! do |x|
-        (m = alpha_pat.match(x)) ? m[1] : nil
-      end
-      acc.compact! # eliminate nils
-    end
-
-    to_field 'lc_b4cutter_facet', extract_marc('050a', first: true)
-
-    # URL Fields
-
-    notfulltext = /abstract|description|sample text|table of contents|/i
-
-    to_field('url_fulltext_display') do |rec, acc|
-      rec.fields('856').each do |f|
-        case f.indicator2
-        when '0'
-          f.find_all { |sf| sf.code == 'u' }.each do |url|
-            acc << url.value
-          end
-        when '2'
-          # do nothing
-        else
-          z3 = [f['z'], f['3']].join(' ')
-          unless notfulltext.match(z3)
-            acc << f['u'] unless f['u'].nil?
-          end
-        end
-      end
-    end
-
-    # Very similar to url_fulltext_display. Should DRY up.
-    to_field 'url_suppl_display' do |rec, acc|
-      rec.fields('856').each do |f|
-        case f.indicator2
-        when '2'
-          f.find_all { |sf| sf.code == 'u' }.each do |url|
-            acc << url.value
-          end
-        when '0'
-          # do nothing
-        else
-          z3 = [f['z'], f['3']].join(' ')
-          if notfulltext.match(z3)
-            acc << f['u'] unless f['u'].nil?
-          end
-        end
-      end
-    end
+    # Edition Statement
+    to_field 'edition_t', extract_marc('250ab')
   end
 end

--- a/app/models/marc_indexer.rb
+++ b/app/models/marc_indexer.rb
@@ -1,4 +1,8 @@
 $LOAD_PATH.unshift './config'
+require './app/models/book'
+config = CicognaraRails::Application.config.database_configuration[::Rails.env]
+ActiveRecord::Base.establish_connection(config)
+
 class MarcIndexer < Blacklight::Marc::Indexer
   # this mixin defines lambda facotry method get_format for legacy marc formats
   include Blacklight::Marc::Indexer::Formats
@@ -209,5 +213,9 @@ class MarcIndexer < Blacklight::Marc::Indexer
 
     # Edition Statement
     to_field 'edition_t', extract_marc('250ab')
+
+    each_record do |record, context|
+      ::Book.create(digital_cico_number: context.output_hash['id'].first)
+    end
   end
 end

--- a/spec/fixtures/cicognara.marc.xml
+++ b/spec/fixtures/cicognara.marc.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<collection>
 <record xmlns="http://www.loc.gov/MARC21/slim">
   <leader>01785cam a2200349 a 4500</leader>
   <controlfield tag="001">8524680</controlfield>
@@ -110,3 +111,4 @@
     <subfield code="h">MICROFICHE 5</subfield>
   </datafield>
 </record>
+</collection>

--- a/spec/models/marc_indexer_spec.rb
+++ b/spec/models/marc_indexer_spec.rb
@@ -41,11 +41,41 @@ RSpec.describe MarcIndexer, type: :model do
     expect(values.first['marc_display']).not_to be nil
   end
 
-  it 'indexes format' do
-    expect(values.first['format']).to eq(['Microfilm'])
-  end
-
   it 'indexes title' do
-    expect(values.first['title_display']).to eq(['Henrici Cornelii Agrippae ab Nettesheym De incertitudine et vanitate scientiarum declamatio inuestiua'])
+    expect(values.first['title_t']).to eq(['Henrici Cornelii Agrippae ab Nettesheym De incertitudine et vanitate scientiarum declamatio inuestiua [microform] / ex postrema authoris recognitione.'])
+  end
+  it 'takes id from dclib in 024' do
+    expect(values.first['id']).to eq(['cico:m87'])
+  end
+  it 'indexes additional titles' do
+    expect(values.first['title_addl_t']).to include 'Henrici Cornelii Agrippae ab Nettesheym De incertitudine et vanitate scientiarum declamatio inuestiua'
+    expect(values.first['title_addl_t']).to include('De incertitudine et vanitate scientiarum declamatio inuestiua')
+  end
+  it 'converts language code to label in language_facet' do
+    expect(values.first['language_facet']).to eq(['Latin'])
+  end
+  it 'adds field subject_t field combining topic/genre/era' do
+    expect(values.first['subject_t']).to include('Learning and scholarship—Early works to 1800')
+    expect(values.first['subject_t']).to include('Medicine—Early works to 1800')
+    expect(values.first['subject_t']).to include('Medicine—History—16th century')
+    expect(values.first['subject_t']).to include('Science—Early works to 1800')
+  end
+  it 'indexes subject_topic_facet' do
+    expect(values.first['subject_topic_facet']).to include('Learning and scholarship')
+    expect(values.first['subject_topic_facet']).to include('Medicine')
+    expect(values.first['subject_topic_facet']).to include('History')
+    expect(values.first['subject_topic_facet']).to include('Science')
+  end
+  it 'indexes subject_genre_facet' do
+    expect(values.first['subject_genre_facet']).to include('Early works to 1800')
+  end
+  it 'indexes subject_era_facet' do
+    expect(values.first['subject_era_facet']).to eq(['16th century'])
+  end
+  it 'indexes field published_t' do
+    expect(values.first['published_t']).to eq(['Coloniae : Apud Theodorum Baumium ..., Anno 1584.'])
+  end
+  it 'takes pub_date from 008' do
+    expect(values.first['pub_date']).to eq([1584])
   end
 end

--- a/spec/models/marc_indexer_spec.rb
+++ b/spec/models/marc_indexer_spec.rb
@@ -78,4 +78,8 @@ RSpec.describe MarcIndexer, type: :model do
   it 'takes pub_date from 008' do
     expect(values.first['pub_date']).to eq([1584])
   end
+  it 'adds book object to database with digital cico number' do
+    expect(Book.where(digital_cico_number: 'cico:m87').size).to be > 0
+  end
+  after(:all) { Book.destroy_all }
 end

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -16,4 +16,5 @@ RSpec.describe 'CatalogController config', type: :request do
       expect(doc['published_t']).to eq(['Coloniae : Apud Theodorum Baumium ..., Anno 1584.'])
     end
   end
+  after(:all) { Book.destroy_all }
 end

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require 'json'
+
+RSpec.describe 'CatalogController config', type: :request do
+  before(:all) do
+    indexer = MarcIndexer.new
+    indexer.process(File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.marc.xml'))
+    get solr_document_path('cico:m87'), format: :json
+  end
+  let(:doc) { JSON.parse(response.body)['response']['document'] }
+  describe 'document stored fields' do
+    it 'stores language_facet for display' do
+      expect(doc['language_facet']).to eq(['Latin'])
+    end
+    it 'stores language_facet for display' do
+      expect(doc['published_t']).to eq(['Coloniae : Apud Theodorum Baumium ..., Anno 1584.'])
+    end
+  end
+end


### PR DESCRIPTION
Updates marc indexer configuration and creates a Book object with the cico number for each MARC record. Uses existing rake task: `MARC_FILE='PATH TO FILE' rake solr:marc:index`
Warning - sqlite can't handle so many writes at once but postgres should be able.