### PR TITLE
pull specific catalogo version on deploy

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,6 @@ module ApplicationHelper
   def catalogo_link(document)
     item = document['id']
     section = document['tei_section_number_display'].first
-    link_to(document['title_display'], "/catalogo/section_#{section}/index.html#item_#{item}")
+    link_to(document['title_display'], page_path("catalogo/section_#{section}", anchor: "item_#{item}"))
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.5.0'
+lock '3.6.1'
 
 set :application, 'cicognara'
 set :repo_url, 'https://github.com/pulibrary/cicognara-rails.git'
@@ -30,7 +30,10 @@ set :linked_files, fetch(:linked_files, []).push('config/secrets.yml', 'db/stagi
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'vendor/bundle')
 
 # Default value for default_env is {}
-# set :default_env, { path: "/opt/ruby/bin:$PATH" }
+set :default_env,
+    'MARCPATH' => '/tmp/cicognara.mrx.xml',
+    'TEIPATH' => '/tmp/catalogo.tei.xml',
+    'CATALOGO_VERSION' => 'v1.0'
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5
@@ -41,11 +44,10 @@ set :passenger_restart_with_touch, true
 
 namespace :deploy do
   after :restart, :clear_cache do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
-      # Here we can do anything such as:
-      # within release_path do
-      #   execute :rake, 'cache:clear'
-      # end
+    on roles(:web), in: :groups, limit: 3, wait: 5 do
+      within release_path do
+        execute :rake, 'tei:deploy'
+      end
     end
   end
 end

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,3 +1,3 @@
 server 'libruby-dev.princeton.edu', user: 'deploy', roles: %w(app web)
 
-set :default_env, fetch(:default_env).merge('RAILS_ENV' => 'staging')
+set :default_env, fetch(:default_env).merge('RAILS_ENV' => 'staging', 'URL_PATH' => 'cicognara/')

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,1 +1,3 @@
 server 'libruby-dev.princeton.edu', user: 'deploy', roles: %w(app web)
+
+set :default_env, fetch(:default_env).merge('RAILS_ENV' => 'staging')

--- a/lib/tasks/tei.rake
+++ b/lib/tasks/tei.rake
@@ -12,8 +12,8 @@ namespace :tei do
     solr.commit
   end
 
+  desc 'Create partials at PARTIALSPATH from document at TEIPATH'
   task :partials do
-    desc 'Create partials at PARTIALSPATH from document at TEIPATH'
     teipath = ENV['TEIPATH'] || File.join(File.dirname(__FILE__), '../../', 'spec/fixtures', 'cicognara.tei.xml')
     partialspath = ENV['PARTIALSPATH'] || File.join(File.dirname(__FILE__), '../../', 'app/views/pages/catalogo/')
     # Generate section partials
@@ -23,5 +23,13 @@ namespace :tei do
     # Generate item partials
     xslpath = File.join(File.dirname(__FILE__), '../', 'xsl', 'partials-item.xsl')
     system(%(java -jar bin/saxon9he.jar -s:#{teipath} -xsl:#{xslpath} path_to_partials=#{partialspath}))
+  end
+
+  desc 'Pulls catalogo tei/marc then indexes and generates partials'
+  task :deploy do
+    `wget https://raw.githubusercontent.com/pulibrary/cicognara-catalogo/#{ENV['CATALOGO_VERSION']}/catalogo.tei.xml -O #{ENV['TEIPATH']}`
+    `wget https://raw.githubusercontent.com/pulibrary/cicognara-catalogo/#{ENV['CATALOGO_VERSION']}/cicognara.mrx.xml -O #{ENV['MARCPATH']}`
+    Rake::Task['tei:index'].invoke
+    Rake::Task['tei:partials'].invoke
   end
 end

--- a/lib/tasks/tei.rake
+++ b/lib/tasks/tei.rake
@@ -18,11 +18,11 @@ namespace :tei do
     partialspath = ENV['PARTIALSPATH'] || File.join(File.dirname(__FILE__), '../../', 'app/views/pages/catalogo/')
     # Generate section partials
     xslpath = File.join(File.dirname(__FILE__), '../', 'xsl', 'partials-section.xsl')
-    system(%(java -jar bin/saxon9he.jar -s:#{teipath} -xsl:#{xslpath} path_to_partials=#{partialspath}))
+    system(%(java -jar bin/saxon9he.jar -s:#{teipath} -xsl:#{xslpath} path_to_partials=#{partialspath} url_path_prefix=#{ENV['URL_PATH']}))
 
     # Generate item partials
     xslpath = File.join(File.dirname(__FILE__), '../', 'xsl', 'partials-item.xsl')
-    system(%(java -jar bin/saxon9he.jar -s:#{teipath} -xsl:#{xslpath} path_to_partials=#{partialspath}))
+    system(%(java -jar bin/saxon9he.jar -s:#{teipath} -xsl:#{xslpath} path_to_partials=#{partialspath} url_path_prefix=#{ENV['URL_PATH']}))
   end
 
   desc 'Pulls catalogo tei/marc then indexes and generates partials'

--- a/lib/xsl/partials-item.xsl
+++ b/lib/xsl/partials-item.xsl
@@ -14,6 +14,7 @@
     <xsl:output method="html" encoding="UTF-8" omit-xml-declaration="yes"/>
 
     <xsl:param name="path_to_partials">/tmp/item-partials</xsl:param>
+    <xsl:param name="url_path_prefix"></xsl:param>
     
     <xsl:template match="/">
         <xsl:apply-templates select="//tei:div[@type='section']/tei:list[@type='catalog']/tei:item" />
@@ -72,7 +73,7 @@
     </xsl:template>
     <xsl:template match="tei:title">
         <span class="catalogo-title">
-          <a class="catalog-link" href="/catalog/{./ancestor::tei:item/@n}">
+          <a class="catalog-link" href="/{$url_path_prefix}catalog/{./ancestor::tei:item/@n}">
               <xsl:apply-templates/>
           </a>
         </span>

--- a/lib/xsl/partials-section.xsl
+++ b/lib/xsl/partials-section.xsl
@@ -14,6 +14,7 @@
     <xsl:output method="html" encoding="UTF-8" omit-xml-declaration="yes"/>
 
     <xsl:param name="path_to_partials">/tmp/item-partials</xsl:param>
+    <xsl:param name="url_path_prefix"></xsl:param>
 
     <xsl:template match="tei:teiCorpus" mode="toc">
         <xsl:param name="current-item-number"/>
@@ -28,7 +29,7 @@
                             <xsl:value-of select="current()/tei:head/tei:seg[@type = 'main']"/>
                         </xsl:when>
                         <xsl:otherwise>
-                            <a href="/catalogo/section_{@n}/index.html">
+                            <a href="/{$url_path_prefix}catalogo/section_{@n}/index.html">
                                 <xsl:value-of select="current()/tei:head/tei:seg[@type = 'main']"/>
                             </a>
                         </xsl:otherwise>
@@ -112,7 +113,7 @@
     </xsl:template>
     <xsl:template match="tei:title">
         <span class="catalogo-title">
-            <a class="catalog-link" href="/catalog/{./ancestor::tei:item/@n}">
+            <a class="catalog-link" href="/{$url_path_prefix}catalog/{./ancestor::tei:item/@n}">
                 <xsl:apply-templates/>
             </a>
         </span>


### PR DESCRIPTION
Capistrano deploy config can now reference a specific tag or branch. Closes #90.
Index solr and regenerate partials on deploy.