### PR TITLE
update static page routes

### DIFF
--- a/app/assets/stylesheets/components/_variables.scss
+++ b/app/assets/stylesheets/components/_variables.scss
@@ -14,4 +14,4 @@ $intro-heading: "Playfair Display", Georgia, serif;
 // bootstrap overrides
 $font-family-serif: "Cardo", Georgia, serif;
 $brand-primary: $black;
-$logo_image: 'cicognara-logo.svg' !default;
+$logo_image: image_path('cicognara-logo.svg') !default;

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,8 +1,8 @@
 <div class="navbar-right">
   <ul class="nav navbar-nav">
-    <li><a href="/about">About</a></li>
-    <li><a href="/partners">Partners</a></li>
-    <li><a href="/contact">Contact</a></li>
-    <li><a href="/news">News</a></li>
+    <li><%= link_to 'About', static_page_path('about') %></li>
+    <li><%= link_to 'Partners', static_page_path('partners') %></li>
+    <li><%= link_to 'Contact', static_page_path('contact') %></li>
+    <li><%= link_to 'News', static_page_path('news') %></li>
   </ul>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,10 +26,10 @@
     <%= content_for(:head) %>
   </head>
   <% if current_page?(root_path) %>
-    <%= render :partial => 'shared/front_header' %>
+    <%= render partial: 'shared/front_header' %>
   <% else %>
   <body class="<%= render_body_class %>">
-    <%= render :partial => 'shared/header_navbar' %>
+    <%= render partial: 'shared/header_navbar' %>
   <% end %>
     <%= render partial: 'shared/ajax_modal' %>
     <% if current_page?(root_path) %>
@@ -43,6 +43,6 @@
       </div>
     </div>
     <% end %>
-  <%= render :partial => 'shared/footer' %>
+  <%= render partial: 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_front_header.html.erb
+++ b/app/views/shared/_front_header.html.erb
@@ -1,10 +1,10 @@
 <body class="splash">
   <header>
       <ul>
-        <li><a href="/about">About</a></li>
-        <li><a href="/partners">Partners</a></li>
-        <li><a href="/contact">Contact</a></li>
-        <li><a href="/news">News</a></li>
+        <li><%= link_to 'About', static_page_path('about') %></li>
+        <li><%= link_to 'Partners', static_page_path('partners') %></li>
+        <li><%= link_to 'Contact', static_page_path('contact') %></li>
+        <li><%= link_to 'News', static_page_path('news') %></li>
       </ul>
     </header>
     <section class="intro">
@@ -13,7 +13,7 @@
             <h1>The Digital Cicognara Library <span class="small"><span class="italic">An</span> Open-Access Collection <span class="italic">of the</span> Early Literature of the Arts</span></h1>
             <div class="search-browse--home">
               <%= render_search_bar  %>
-              <%= link_to 'Browse the Catalogo', 'catalogo', class: 'btn btn-primary browse-catalogo' %>
+              <%= link_to 'Browse the Catalogo', browse_catalogo_path, class: 'btn btn-primary browse-catalogo' %>
             </div>
           </div>
         </div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class="collapse navbar-collapse" id="user-util-collapse">
-      <%= render :partial=>'/user_util_links' %>
+      <%= render partial: '/user_util_links' %>
     </div>
   </div>
 </div>
@@ -19,6 +19,6 @@
 <div id="search-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="<%= container_classes %>">
     <%= render_search_bar  %>
-    <%= link_to 'Browse the Catalogo', page_path("catalogo/section_1.1"), class: 'btn btn-primary browse-catalogo' %>
+    <%= link_to 'Browse the Catalogo', browse_catalogo_path, class: 'btn btn-primary browse-catalogo' %>
   </div>
 </div>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,7 +33,7 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'vendor/bundle')
 set :default_env,
     'MARCPATH' => '/tmp/cicognara.mrx.xml',
     'TEIPATH' => '/tmp/catalogo.tei.xml',
-    'CATALOGO_VERSION' => 'v1.0'
+    'CATALOGO_VERSION' => 'v1.0.1'
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
+  config.relative_url_root = '/cicognara'
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,16 +29,9 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/catalogo' => 'high_voltage/pages#show', as: :browse_catalogo, id: 'catalogo/section_1.1'
   get '/*id/index.html' => 'high_voltage/pages#show', as: :page, format: false
-
-  # static pages
-  get '/about' => 'high_voltage/pages#show', id: 'about'
-  get '/partners' => 'high_voltage/pages#show', id: 'partners'
-  get '/contact' => 'high_voltage/pages#show', id: 'contact'
-  get '/news' => 'high_voltage/pages#show', id: 'news'
-  get '/home' => 'high_voltage/pages#show', id: 'home'
-
-  get '/catalogo' => 'high_voltage/pages#show', id: 'catalogo/section_1.1'
+  get '/*id' => 'high_voltage/pages#show', as: :static_page, format: false
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/routing/high_voltage_routing_spec.rb
+++ b/spec/routing/high_voltage_routing_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'high_voltage/pages', type: :routing do
     it 'supports nested routes' do
       expect(get: '/catalogo/section_1.5/index.html').to route_to('high_voltage/pages#show', id: 'catalogo/section_1.5')
     end
-    it 'index.html must be present' do
-      expect(get: '/catalogo/section_1.5').not_to be_routable
+    it 'also supports routes without index.html' do
+      expect(get: '/catalogo/section_1.5').to route_to('high_voltage/pages#show', id: 'catalogo/section_1.5')
     end
   end
 end


### PR DESCRIPTION
Currently deployed. Updated cicognara-catalog version. Change routes to allow links/assets to work with relative root url in staging environment.
http://libruby-dev.princeton.edu/cicognara/catalog/1978