### PR TITLE
Create Entry model and adjust indexing.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ end
 group :development, :test do
   gem 'simplecov', '~> 0.9', require: false
   gem 'rails-controller-testing'
+  gem 'pry-rails'
+  gem 'pry-byebug'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -168,6 +169,15 @@ GEM
     pg (0.18.4)
     pkg-config (1.1.7)
     powerpack (0.1.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -326,6 +336,8 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   pg
+  pry-byebug
+  pry-rails
   rails (~> 5.0)
   rails-controller-testing
   rsolr (~> 1.0)
@@ -344,4 +356,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.1
+   1.12.5

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,11 @@ class Book < ActiveRecord::Base
   has_many :creator_roles
   has_many :book_subjects
   has_many :subjects, through: :book_subjects
+  has_many :entry_books
+  has_many :entries, through: :entry_books
+  attribute :marcxml, :marc_nokogiri_type
+
+  def to_solr
+    Cicognara::BookIndexer.new(self).to_solr.values.first
+  end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+class Entry < ApplicationRecord
+  has_many :entry_books
+  has_many :books, through: :entry_books
+  attribute :tei, :tei_type
+
+  def to_solr
+    Cicognara::CatalogoItem.new(self).solr_doc
+  end
+
+  def n
+    ns = tei.xpath('./@n')
+    ns.empty? ? 'NO_N' : ns.first.value
+  end
+
+  def corresp
+    c = tei.xpath('./@corresp')
+    c.empty? ? [] : c.first.value.split
+  end
+
+  def item_label
+    title = tei.xpath('./label')
+    NormalizedString.new(title.first).value
+  end
+
+  def item_titles
+    titles = tei.xpath('./bibl/title')
+    NormalizedString.new(titles).array_value
+  end
+
+  def item_authors
+    authors = tei.xpath('./bibl/author')
+    NormalizedString.new(authors).array_value
+  end
+
+  def item_pubs
+    pubs = tei.xpath('./bibl/pubPlace')
+    NormalizedString.new(pubs).array_value
+  end
+
+  def item_dates
+    dates = tei.xpath('.//date')
+    NormalizedString.new(dates).array_value
+  end
+
+  def item_notes
+    notes = tei.xpath('./note')
+    NormalizedString.new(notes).array_value
+  end
+
+  def text
+    NormalizedString.new(tei).value
+  end
+
+  class NormalizedString
+    attr_reader :string
+    def initialize(string)
+      @string = string
+    end
+
+    def value
+      string.text.gsub(/\s+/, ' ').strip
+    end
+
+    def array_value
+      string.map do |x|
+        NormalizedString.new(x).value
+      end
+    end
+  end
+end

--- a/app/models/entry_book.rb
+++ b/app/models/entry_book.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+class EntryBook < ApplicationRecord
+  belongs_to :book
+  belongs_to :entry
+end

--- a/app/models/marc_indexer.rb
+++ b/app/models/marc_indexer.rb
@@ -222,14 +222,6 @@ class MarcIndexer < Blacklight::Marc::Indexer
     to_field 'edition_t', extract_marc('250ab')
 
     each_record do |record, context|
-      begin
-        ::Book.where(digital_cico_number: context.output_hash['id'].first).first_or_create
-      # retry if the sqlite3 is locked...
-      rescue ActiveRecord::StatementInvalid, SQLite3::BusyException => e
-        puts "trying again: #{context.output_hash['id'].first}"
-        ::Book.where(digital_cico_number: context.output_hash['id'].first).first_or_create
-      end
-
       # add display fields
       context.output_hash['dclib_display'] = context.output_hash['id']
       context.output_hash['published_display'] = context.output_hash['published_t'] unless context.output_hash['published_t'].nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,10 +14,6 @@ class User < ActiveRecord::Base
     self.role ||= 'user'
   end
 
-  if Blacklight::Utils.needs_attr_accessible?
-    attr_accessible :email, :password, :password_confirmation
-  end
-
   # Connects this user object to Blacklights Bookmarks.
   include Blacklight::User
   # Include default devise modules. Others available are:

--- a/app/types/marc_nokogiri_type.rb
+++ b/app/types/marc_nokogiri_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class MarcNokogiriType < NokogiriType
+  def cast(value)
+    result = super
+    return result if result.blank? || result.root.blank? || result.root.namespaces.present?
+    result.root['xmlns'] = 'http://www.loc.gov/MARC21/slim'
+    result
+  end
+end

--- a/app/types/nokogiri_type.rb
+++ b/app/types/nokogiri_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class NokogiriType < ActiveRecord::Type::Value
+  def cast(value)
+    Nokogiri::XML(value.to_s)
+  end
+
+  def serialize(value)
+    value.to_xml
+  end
+end

--- a/app/types/tei_type.rb
+++ b/app/types/tei_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class TeiType < ActiveRecord::Type::Value
+  def cast(value)
+    Nokogiri::XML(value.to_s).xpath('./item')
+  end
+
+  def serialize(value)
+    value.to_s
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,6 @@ module CicognaraRails
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.autoload_paths << Rails.root.join('lib')
   end
 end

--- a/config/initializers/tei_type.rb
+++ b/config/initializers/tei_type.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+ActiveRecord::Type.register(:tei_type, TeiType)
+ActiveRecord::Type.register(:nokogiri_type, NokogiriType)
+ActiveRecord::Type.register(:marc_nokogiri_type, MarcNokogiriType)

--- a/db/migrate/20161024205411_create_entries.rb
+++ b/db/migrate/20161024205411_create_entries.rb
@@ -1,0 +1,16 @@
+class CreateEntries < ActiveRecord::Migration[5.0]
+  def change
+    create_table :entries do |t|
+      t.string :section_head
+      t.string :section_display
+      t.string :section_number
+      t.string :n_value
+      t.string :entry_id
+      t.text :tei
+
+      t.timestamps
+    end
+    add_index :entries, :n_value
+    add_index :entries, :entry_id
+  end
+end

--- a/db/migrate/20161024205730_create_entry_books.rb
+++ b/db/migrate/20161024205730_create_entry_books.rb
@@ -1,0 +1,10 @@
+class CreateEntryBooks < ActiveRecord::Migration[5.0]
+  def change
+    create_table :entry_books do |t|
+      t.references :book, foreign_key: true
+      t.references :entry, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,6 +65,28 @@ ActiveRecord::Schema.define(version: 20161027005742) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "entries", force: :cascade do |t|
+    t.string   "section_head"
+    t.string   "section_display"
+    t.string   "section_number"
+    t.string   "n_value"
+    t.string   "entry_id"
+    t.text     "tei"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["entry_id"], name: "index_entries_on_entry_id"
+    t.index ["n_value"], name: "index_entries_on_n_value"
+  end
+
+  create_table "entry_books", force: :cascade do |t|
+    t.integer  "book_id"
+    t.integer  "entry_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["book_id"], name: "index_entry_books_on_book_id"
+    t.index ["entry_id"], name: "index_entry_books_on_entry_id"
+  end
+
   create_table "roles", force: :cascade do |t|
     t.string   "label"
     t.string   "uri"

--- a/lib/cicognara/book_indexer.rb
+++ b/lib/cicognara/book_indexer.rb
@@ -1,0 +1,39 @@
+module Cicognara
+  class BookIndexer
+    attr_reader :books
+    def initialize(books)
+      @books = Array(books)
+    end
+
+    def to_solr
+      @to_solr ||=
+        Tempfile.open do |f|
+          f.write combined_marc
+          f.close
+          indexer.process(f.path)
+          indexer.writer.all_records
+        end
+    end
+
+    private
+
+    def indexer
+      @indexer ||=
+        MarcIndexer.new.tap do |i|
+          i.writer = SolrWriterAccumulator.new(i.settings)
+        end
+    end
+
+    def all_marc
+      books.map(&:marcxml).map(&:clone)
+    end
+
+    def combined_marc
+      builder = Nokogiri::XML('<collection></collection>')
+      all_marc.each do |record|
+        builder.root << record.root
+      end
+      builder.to_xml
+    end
+  end
+end

--- a/lib/cicognara/bulk_entry_indexer.rb
+++ b/lib/cicognara/bulk_entry_indexer.rb
@@ -1,0 +1,26 @@
+module Cicognara
+  class BulkEntryIndexer
+    attr_reader :entries
+    def initialize(entries)
+      @entries = entries
+    end
+
+    def book_documents
+      @book_documents ||= BookIndexer.new(books).to_solr
+    end
+
+    def books
+      entries.flat_map(&:books)
+    end
+
+    def entry_documents
+      entries_with_cached_book_solrs.map(&:to_solr)
+    end
+
+    def entries_with_cached_book_solrs
+      entries.map do |entry|
+        WithBookCache.new(entry, book_documents)
+      end
+    end
+  end
+end

--- a/lib/cicognara/catalogo_item.rb
+++ b/lib/cicognara/catalogo_item.rb
@@ -1,107 +1,63 @@
 # catalogo_item.rb
-class CatalogoItem
-  attr_accessor :xml_element
+module Cicognara
+  class CatalogoItem
+    attr_accessor :entry
+    delegate :n, :text, :item_authors, :item_pubs, :item_dates, :item_notes, :item_titles, :item_label, :section_display, :section_head, :section_number, :books, :corresp, to: :entry
 
-  def initialize(xml_element, xsl, marc_collection, section_info)
-    @xml_element = xml_element
-    @xsl = xsl
-    @marc_collection = marc_collection
-    @section = section_info
-  end
-
-  def n
-    ns = @xml_element.xpath('./@n')
-    ns.empty? ? 'NO_N' : ns.first.value
-  end
-
-  def corresp
-    c = @xml_element.xpath('./@corresp')
-    c.empty? ? [] : c.first.value.split
-  end
-
-  def item_label
-    title = @xml_element.xpath('./tei:label', tei: 'http://www.tei-c.org/ns/1.0')
-    title.first.text.gsub(/\s+/, ' ').strip unless title.empty?
-  end
-
-  def item_titles
-    titles = @xml_element.xpath('./tei:bibl/tei:title', tei: 'http://www.tei-c.org/ns/1.0')
-    titles.map { |t| t.text.gsub(/\s+/, ' ').strip } unless titles.empty?
-  end
-
-  def item_authors
-    authors = @xml_element.xpath('./tei:bibl/tei:author', tei: 'http://www.tei-c.org/ns/1.0')
-    authors.map { |a| a.text.gsub(/\s+/, ' ').strip } unless authors.empty?
-  end
-
-  def item_pubs
-    pubs = @xml_element.xpath('./tei:bibl/tei:pubPlace', tei: 'http://www.tei-c.org/ns/1.0')
-    pubs.map { |p| p.text.gsub(/\s+/, ' ').strip } unless pubs.empty?
-  end
-
-  def item_dates
-    dates = @xml_element.xpath('.//tei:date', tei: 'http://www.tei-c.org/ns/1.0')
-    dates.map { |d| d.text.gsub(/\s+/, ' ').strip } unless dates.empty?
-  end
-
-  def item_notes
-    notes = @xml_element.xpath('./tei:note', tei: 'http://www.tei-c.org/ns/1.0')
-    notes.map { |n| n.text.gsub(/\s+/, ' ').strip } unless notes.empty?
-  end
-
-  def text
-    @xml_element.to_str.gsub(/\s+/, ' ').strip
-  end
-
-  def solr_doc
-    doc = doc_tei_fields
-    unless corresp.empty?
-      doc[:dclib_s] = corresp
-      book_fields = get_marc_fields(corresp)
-      doc.merge!(book_fields)
+    def initialize(entry)
+      @entry = entry
     end
-    doc[:title_display] = solr_title_display(item_label || n)
-    doc
-  end
 
-  private
-
-  def doc_tei_fields
-    { id: n, cico_s: n, tei_description_unstem_search: text, tei_section_display: @section[:display],
-      tei_section_head_italian: @section[:head], tei_section_number_display: @section[:number],
-      tei_author_txt: item_authors, tei_pub_txt: item_pubs, tei_date_display: item_dates,
-      tei_note_italian: item_notes, tei_title_txt: item_titles, tei_section_facet: @section[:display] }
-  end
-
-  def solr_title_display(label)
-    "Catalogo Item #{label.chomp('.')}"
-  end
-
-  def get_marc_fields(dclib_nums)
-    book_fields = {}
-    dclib_nums.each do |num|
-      marc = @marc_collection[num]
-      book_fields.merge!(marc) { |_, oldval, newval| (newval + oldval).uniq } unless marc.nil?
+    def solr_doc
+      doc = doc_tei_fields
+      unless corresp.empty?
+        doc[:dclib_s] = corresp
+        book_fields = marc_fields
+        doc.merge!(book_fields)
+      end
+      doc[:title_display] = solr_title_display(item_label || n)
+      doc
     end
-    # fields to ignore
-    remove_display_fields(book_fields)
 
-    # single-valued fields
-    field_first_value(book_fields)
+    private
 
-    book_fields['text'] = book_fields['text'].join(' ') unless book_fields['text'].nil?
-    book_fields
-  end
+    def doc_tei_fields
+      { id: n, cico_s: n, tei_description_unstem_search: text, tei_section_display: section_display,
+        tei_section_head_italian: section_head, tei_section_number_display: section_number,
+        tei_author_txt: item_authors, tei_pub_txt: item_pubs, tei_date_display: item_dates,
+        tei_note_italian: item_notes, tei_title_txt: item_titles, tei_section_facet: section_display }
+    end
 
-  def field_first_value(book)
-    %w(marc_display title_sort author_sort
-       pub_date).each { |f| book[f] = book[f].first unless book[f].nil? }
-  end
+    def solr_title_display(label)
+      "Catalogo Item #{label.chomp('.')}"
+    end
 
-  def remove_display_fields(book)
-    %w(id format title_display author_display published_display
-       title_addl_display title_added_entry_display title_series_display
-       subject_display contents_display edition_display language_display
-       related_name_display dclib_display).each { |f| book.delete(f) }
+    def marc_fields
+      book_fields = {}
+      books.each do |book|
+        book_doc = book.to_solr
+        book_fields.merge!(book_doc) { |_, oldval, newval| (newval + oldval).uniq } unless book_doc.nil?
+      end
+      # fields to ignore
+      remove_display_fields(book_fields)
+
+      # single-valued fields
+      field_first_value(book_fields)
+
+      book_fields['text'] = book_fields['text'].join(' ') unless book_fields['text'].nil?
+      book_fields
+    end
+
+    def field_first_value(book)
+      %w(marc_display title_sort author_sort
+         pub_date).each { |f| book[f] = book[f].first unless book[f].nil? }
+    end
+
+    def remove_display_fields(book)
+      %w(id format title_display author_display published_display
+         title_addl_display title_added_entry_display title_series_display
+         subject_display contents_display edition_display language_display
+         related_name_display dclib_display).each { |f| book.delete(f) }
+    end
   end
 end

--- a/lib/cicognara/marc_record.rb
+++ b/lib/cicognara/marc_record.rb
@@ -1,0 +1,12 @@
+module Cicognara
+  class MarcRecord
+    attr_reader :source
+    def initialize(source)
+      @source = source
+    end
+
+    def book_id
+      source.xpath('./marc:datafield[@tag=024]/marc:subfield[@code="a" and ../marc:subfield="dclib"]', marc: 'http://www.loc.gov/MARC21/slim').map(&:text).first
+    end
+  end
+end

--- a/lib/cicognara/section.rb
+++ b/lib/cicognara/section.rb
@@ -1,0 +1,24 @@
+module Cicognara
+  class Section
+    attr_reader :section
+    def initialize(section)
+      @section = section
+    end
+
+    def section_number
+      section.xpath('@n').first.value
+    end
+
+    def section_head
+      section.xpath('tei:head', tei: 'http://www.tei-c.org/ns/1.0').first.text
+    end
+
+    def section_display
+      section.xpath("tei:head/tei:seg[@type='main']", tei: 'http://www.tei-c.org/ns/1.0').first.text
+    end
+
+    def items
+      section.xpath(".//tei:list[@type='catalog']/tei:item", tei: 'http://www.tei-c.org/ns/1.0')
+    end
+  end
+end

--- a/lib/cicognara/tei_indexer.rb
+++ b/lib/cicognara/tei_indexer.rb
@@ -1,43 +1,83 @@
 # tei_indexer.rb
 require 'nokogiri'
 require 'cicognara/catalogo_item'
+require 'cicognara/with_book_cache'
+require 'cicognara/bulk_entry_indexer'
+require 'cicognara/section'
+require 'cicognara/marc_record'
 require './app/models/marc_indexer'
 
-class TEIIndexer
-  attr_accessor :catalogo, :items, :marc_collection
+module Cicognara
+  class TEIIndexer
+    attr_accessor :catalogo, :marc, :books, :entries
 
-  def initialize(pathtotei, pathtoxsl, pathtomarc)
-    @catalogo = File.open(pathtotei) { |f| Nokogiri::XML(f) }
-    @items = []
-    @marc_collection = prepare_marc(pathtomarc)
-    @xsl = File.open(pathtoxsl) { |f| Nokogiri::XSLT(f) }
-    sections = @catalogo.xpath("//tei:div[@type='section']", 'tei' => 'http://www.tei-c.org/ns/1.0')
-    sections.each { |section| process_section(section) }
-  end
-
-  def solr_docs
-    docs = []
-    @items.each { |i| docs.push(i.solr_doc) }
-    docs
-  end
-
-  private
-
-  def process_section(section)
-    section_number = section.xpath('@n')
-    section_head = section.xpath('tei:head', tei: 'http://www.tei-c.org/ns/1.0').first.text
-    section_display = section.xpath("tei:head/tei:seg[@type='main']", tei: 'http://www.tei-c.org/ns/1.0').first.text
-    section_info = { number: section_number, head: section_head, display: section_display }
-    xpath = section.xpath(".//tei:list[@type='catalog']/tei:item", tei: 'http://www.tei-c.org/ns/1.0')
-    xpath.each do |i|
-      items.push(CatalogoItem.new(i, @xsl, @marc_collection, section_info))
+    def initialize(pathtotei, pathtomarc)
+      @catalogo = File.open(pathtotei) { |f| Nokogiri::XML(f) }
+      @marc = File.open(pathtomarc) { |f| Nokogiri::XML(f) }
+      build_entries
+      entries.each(&:save)
+      books.each(&:save)
     end
-  end
 
-  def prepare_marc(pathtomarc)
-    indexer = MarcIndexer.new
-    indexer.writer = SolrWriterAccumulator.new(indexer.settings)
-    indexer.process(pathtomarc)
-    indexer.writer.all_records
+    def solr_docs
+      @solr_docs ||= bulk_entry_indexer.book_documents.values + bulk_entry_indexer.entry_documents
+    end
+
+    def entries
+      @entries ||= sections.flat_map { |section| process_section(section) }
+    end
+
+    def books
+      @books ||= process_marc_records
+    end
+
+    def grouped_books
+      books.group_by(&:digital_cico_number)
+    end
+
+    private
+
+    def build_entries
+      entries.each do |entry|
+        next unless entry.corresp.present?
+        entry.books = []
+        entry.corresp.each do |book_id|
+          entry.books << grouped_books[book_id] if grouped_books[book_id]
+        end
+      end
+    end
+
+    def bulk_entry_indexer
+      @bulk_entry_indexer ||= BulkEntryIndexer.new(entries)
+    end
+
+    def sections
+      @sections ||= catalogo.xpath("//tei:div[@type='section']", 'tei' => 'http://www.tei-c.org/ns/1.0')
+    end
+
+    def process_section(section)
+      section = Section.new(section)
+      section.items.map do |i|
+        entry = Entry.find_or_initialize_by(entry_id: i.attribute('id').value, section_number: section.section_number, section_head: section.section_head, section_display: section.section_display)
+        entry.tei = i
+        entry.tei_will_change!
+        entry.n_value = entry.n
+        entry
+      end
+    end
+
+    def process_marc_records
+      marc_records.map do |record|
+        record = MarcRecord.new(record)
+        book = Book.find_or_initialize_by(digital_cico_number: record.book_id)
+        book.marcxml = record.source
+        book.marcxml_will_change!
+        book
+      end
+    end
+
+    def marc_records
+      marc.xpath('.//marc:record', marc: 'http://www.loc.gov/MARC21/slim')
+    end
   end
 end

--- a/lib/cicognara/with_book_cache.rb
+++ b/lib/cicognara/with_book_cache.rb
@@ -1,0 +1,35 @@
+module Cicognara
+  ##
+  # Used when all the appropriate solr records for the books attached to events
+  # were generated at once, as in a bulk ingest from a single MARC XML file.
+  class WithBookCache < SimpleDelegator
+    attr_reader :entry, :book_records
+    def initialize(entry, book_records)
+      @entry = entry
+      @book_records = book_records
+      super(entry)
+    end
+
+    def to_solr
+      CatalogoItem.new(self).solr_doc
+    end
+
+    def books
+      super.map do |book|
+        BookWithCachedSolr.new(book, book_records[book.digital_cico_number])
+      end
+    end
+
+    class BookWithCachedSolr < SimpleDelegator
+      attr_reader :book, :solr_documents
+      def initialize(book, solr_documents)
+        super(book)
+        @solr_documents = solr_documents
+      end
+
+      def to_solr
+        Array.wrap(solr_documents).first
+      end
+    end
+  end
+end

--- a/lib/tasks/tei.rake
+++ b/lib/tasks/tei.rake
@@ -2,13 +2,12 @@ require 'cicognara/tei_indexer'
 
 namespace :tei do
   desc 'index solr documents from path to document at TEIPATH and MARCPATH.'
-  task :index do
+  task index: :environment do
     teipath = ENV['TEIPATH'] || File.join(File.dirname(__FILE__), '../../', 'spec/fixtures', 'cicognara.tei.xml')
     marcpath = ENV['MARCPATH'] || File.join(File.dirname(__FILE__), '../../', 'spec/fixtures', 'cicognara.marc.xml')
-    xslpath = File.join(File.dirname(__FILE__), '../', 'xsl', 'catalogo-item-to-html.xsl')
     solr_server = Blacklight.connection_config[:url]
     solr = RSolr.connect(url: solr_server)
-    solr.add(TEIIndexer.new(teipath, xslpath, marcpath).solr_docs)
+    solr.add(Cicognara::TEIIndexer.new(teipath, marcpath).solr_docs)
     solr.commit
   end
 

--- a/spec/cicognara/tei_indexer_spec.rb
+++ b/spec/cicognara/tei_indexer_spec.rb
@@ -1,13 +1,14 @@
 # coding: utf-8
+# frozen_string_literal: true
 require 'rails_helper'
-require 'tei_helper'
 
-describe TEIIndexer do
+describe Cicognara::TEIIndexer do
   before(:all) do
+    Book.destroy_all
+    Entry.destroy_all
     pathtotei = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.tei.xml')
     pathtomarc = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.marc.xml')
-    pathtoxsl = File.join(File.dirname(__FILE__), '../..', 'lib', 'xsl', 'catalogo-item-to-html.xsl')
-    @subject = described_class.new(pathtotei, pathtoxsl, pathtomarc)
+    @subject = described_class.new(pathtotei, pathtomarc)
   end
 
   after(:all) { Book.destroy_all }
@@ -17,124 +18,16 @@ describe TEIIndexer do
     end
   end
 
-  describe '#items' do
-    it 'has a length of 3' do
-      expect(@subject.items.length).to eq 5
-    end
-
-    it 'has an n property' do
-      expect(@subject.items.first.n).not_to be_nil
-    end
-
-    it 'has a correct n property' do
-      expect(@subject.items.first.n).to eq('1')
-    end
-
-    describe '#corresp' do
-      it 'has a corresp array' do
-        expect(@subject.items.first.corresp.class).to eq(Array)
-      end
-
-      it 'is empty when there is no @corresp attr' do
-        expect(@subject.items.first.corresp.length).to eq 0
-      end
-
-      it 'has length 1 when there is one value in @corresp' do
-        expect(@subject.items[1].corresp.length).to eq 1
-      end
-
-      it 'has the right value' do
-        expect(@subject.items[1].corresp[0]).to eq('cico:m87')
-      end
-
-      it 'has length 2 when there are two values in @corresp' do
-        expect(@subject.items[2].corresp.length).to eq 2
-      end
-
-      it 'has the right value' do
-        expect(@subject.items[2].corresp[1]).to eq('cico:98g')
-      end
-    end
-
-    describe '#text' do
-      it 'is a string' do
-        expect(@subject.items.first.text.class).to eq(String)
-      end
-    end
-
-    describe '#solr_doc' do
-      it 'is a hash' do
-        expect(@subject.items.first.solr_doc.class).to eq(Hash)
-      end
-
-      it 'has an id property' do
-        expect(@subject.items.first.solr_doc[:id]).not_to be_nil
-      end
-
-      it 'has the right id property' do
-        expect(@subject.items.first.solr_doc[:id]).to eq('1')
-      end
-
-      it 'has a cico_s field' do
-        expect(@subject.items.first.solr_doc[:cico_s]).not_to be_nil
-      end
-
-      it 'has the right cico_s field value' do
-        expect(@subject.items.first.solr_doc[:cico_s]).to eq('1')
-      end
-
-      it 'has a tei_description_unstem_search field' do
-        expect(@subject.items.first.solr_doc[:tei_description_unstem_search]).not_to be_nil
-      end
-
-      it 'has a tei_notes_txt field' do
-        expect(@subject.items.first.solr_doc[:tei_note_italian]).not_to be_nil
-      end
-
-      it 'does not have dclib_s field when @corresp is not present' do
-        expect(@subject.items.first.solr_doc[:dclib_s]).to be_nil
-      end
-
-      it 'has dclib_s field when @corresp is present' do
-        expect(@subject.items[1].solr_doc[:dclib_s]).not_to be_nil
-      end
-
-      it 'has the right value for the dclib_s field' do
-        expect(@subject.items[1].solr_doc[:dclib_s].first).to eq('cico:m87')
-      end
-
-      it 'dclib_s field to have 2 values when @corresp has 2 values' do
-        expect(@subject.items[2].solr_doc[:dclib_s].length).to eq(2)
-      end
-
-      it 'indexes the item number for display' do
-        expect(@subject.items[1].solr_doc[:title_display]).to include('2')
-      end
-    end
-
-    describe 'marc-related fields' do
-      it 'includes marc fields for indexing' do
-        expect(@subject.items[1].solr_doc['title_addl_t']).to include('De incertitudine et vanitate scientiarum declamatio inuestiua')
-      end
-
-      it 'excludes marc fields for display' do
-        expect(@subject.items[1].solr_doc['title_addl_display']).to be_nil
-      end
-
-      it 'keeps only single value for sort fields for entries with multiple marc records' do
-        expect(@subject.items[2].solr_doc['pub_date']).to eq(1541)
-      end
-
-      it 'merges fields across multiple marc records' do
-        expect(@subject.items[2].solr_doc['subject_topic_facet']).to include('Humanism')
-        expect(@subject.items[2].solr_doc['subject_topic_facet']).to include('Conduct of life')
-      end
+  describe '#books' do
+    it 'builds the same index as if #to_solr was called' do
+      expect(@subject.books[0].to_solr).to eq @subject.solr_docs[0]
+      expect(@subject.solr_docs[4]).to eq @subject.entries[1].to_solr
     end
   end
 
   describe '#solr_docs' do
-    it 'has a length of 5' do
-      expect(@subject.solr_docs.length).to eq 5
+    it 'has a length of 8' do
+      expect(@subject.solr_docs.length).to eq 8
     end
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
-require 'tei_helper'
 
 RSpec.describe CatalogController, type: :controller do
   before(:all) do
     marc = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.marc.xml')
     tei = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.tei.xml')
-    xsl = File.join(File.dirname(__FILE__), '..', '..', 'lib', 'xsl', 'catalogo-item-to-html.xsl')
     solr = RSolr.connect(url: Blacklight.connection_config[:url])
-    solr.add(TEIIndexer.new(tei, xsl, marc).solr_docs)
+    solr.add(Cicognara::TEIIndexer.new(tei, marc).solr_docs)
     solr.commit
   end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'tei_helper'
 
 RSpec.describe 'searching', type: :feature do
   before(:all) do
@@ -7,9 +6,8 @@ RSpec.describe 'searching', type: :feature do
     MarcIndexer.new.process(marc)
 
     tei = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.tei.xml')
-    xsl = File.join(File.dirname(__FILE__), '..', '..', 'lib', 'xsl', 'catalogo-item-to-html.xsl')
     solr = RSolr.connect(url: Blacklight.connection_config[:url])
-    solr.add(TEIIndexer.new(tei, xsl, marc).solr_docs)
+    solr.add(Cicognara::TEIIndexer.new(tei, marc).solr_docs)
     solr.commit
   end
 

--- a/spec/features/view_spec.rb
+++ b/spec/features/view_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'tei_helper'
 
 RSpec.describe 'entry views', type: :feature do
   before(:all) do
@@ -7,9 +6,8 @@ RSpec.describe 'entry views', type: :feature do
     MarcIndexer.new.process(marc)
 
     tei = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.tei.xml')
-    xsl = File.join(File.dirname(__FILE__), '..', '..', 'lib', 'xsl', 'catalogo-item-to-html.xsl')
     solr = RSolr.connect(url: Blacklight.connection_config[:url])
-    solr.add(TEIIndexer.new(tei, xsl, marc).solr_docs)
+    solr.add(Cicognara::TEIIndexer.new(tei, marc).solr_docs)
     solr.commit
   end
 

--- a/spec/models/entry_book_spec.rb
+++ b/spec/models/entry_book_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe EntryBook, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Entry, type: :model do
+  before(:all) do
+    marc = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.marc.xml')
+    tei = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.tei.xml')
+    solr = RSolr.connect(url: Blacklight.connection_config[:url])
+    solr.add(Cicognara::TEIIndexer.new(tei, marc).solr_docs)
+    solr.commit
+  end
+  subject { described_class.first }
+
+  describe '#entries' do
+    it 'has an n property' do
+      expect(subject.n).not_to be_nil
+    end
+
+    it 'puts the n property in the database' do
+      expect(subject.n_value).to eq subject.n
+    end
+
+    it 'has a correct n property' do
+      expect(subject.n).to eq('1')
+    end
+
+    describe '#corresp' do
+      it 'has a corresp array' do
+        expect(subject.corresp.class).to eq(Array)
+      end
+
+      it 'is empty when there is no @corresp attr' do
+        expect(subject.corresp.length).to eq 0
+      end
+
+      context 'when there is one value in @corresp' do
+        subject { described_class.second }
+
+        it 'has length 1' do
+          expect(subject.corresp.length).to eq 1
+        end
+
+        it 'has the right value' do
+          expect(subject.corresp[0]).to eq('cico:m87')
+        end
+      end
+
+      context 'when there are two values in @corresp' do
+        subject { described_class.third }
+
+        it 'has length 2' do
+          expect(subject.corresp.length).to eq 2
+        end
+
+        it 'has the right value' do
+          expect(subject.corresp[1]).to eq('cico:98g')
+        end
+      end
+    end
+
+    describe '#text' do
+      it 'is a string' do
+        expect(subject.text.class).to eq(String)
+      end
+    end
+
+    describe '#to_solr' do
+      it 'is a hash' do
+        expect(subject.to_solr.class).to eq(Hash)
+      end
+
+      it 'has an id property' do
+        expect(subject.to_solr[:id]).not_to be_nil
+      end
+
+      it 'has the right id property' do
+        expect(subject.to_solr[:id]).to eq('1')
+      end
+
+      it 'has a cico_s field' do
+        expect(subject.to_solr[:cico_s]).not_to be_nil
+      end
+
+      it 'has the right cico_s field value' do
+        expect(subject.to_solr[:cico_s]).to eq('1')
+      end
+
+      it 'has a tei_description_unstem_search field' do
+        expect(subject.to_solr[:tei_description_unstem_search]).not_to be_nil
+      end
+
+      it 'has a tei_notes_txt field' do
+        expect(subject.to_solr[:tei_note_italian]).not_to be_nil
+      end
+
+      it 'does not have dclib_s field when @corresp is not present' do
+        expect(subject.to_solr[:dclib_s]).to be_nil
+      end
+
+      context 'when corresp is present' do
+        subject { described_class.second }
+
+        it 'has dclib_s field' do
+          expect(subject.to_solr[:dclib_s]).not_to be_nil
+        end
+
+        it 'has the right value for the dclib_s field' do
+          expect(subject.to_solr[:dclib_s].first).to eq('cico:m87')
+        end
+
+        it 'indexes the item number for display' do
+          expect(subject.to_solr[:title_display]).to include('2')
+        end
+      end
+      context 'when corresp has 2 values' do
+        subject { described_class.third }
+
+        it 'dclib_s field has 2 values' do
+          expect(subject.to_solr[:dclib_s].length).to eq(2)
+        end
+      end
+    end
+
+    describe 'marc-related fields' do
+      context 'when corresp has one value' do
+        subject { described_class.second }
+
+        it 'includes marc fields for indexing' do
+          expect(subject.to_solr['title_addl_t']).to include('De incertitudine et vanitate scientiarum declamatio inuestiua')
+        end
+
+        it 'excludes marc fields for display' do
+          expect(subject.to_solr['title_addl_display']).to be_nil
+        end
+      end
+
+      context 'when corresp has two values' do
+        subject { described_class.third }
+
+        it 'keeps only single value for sort fields for entries with multiple marc records' do
+          expect(subject.to_solr['pub_date']).to eq(1541)
+        end
+
+        it 'merges fields across multiple marc records' do
+          expect(subject.to_solr['subject_topic_facet']).to include('Humanism')
+          expect(subject.to_solr['subject_topic_facet']).to include('Conduct of life')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/marc_indexer_spec.rb
+++ b/spec/models/marc_indexer_spec.rb
@@ -76,8 +76,5 @@ RSpec.describe MarcIndexer, type: :model do
   it 'takes pub_date from 008' do
     expect(@values.first['pub_date']).to eq([1584])
   end
-  it 'adds book object to database with digital cico number' do
-    expect(Book.where(digital_cico_number: 'cico:m87').size).to eq 1
-  end
   after(:all) { Book.destroy_all }
 end

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -3,8 +3,13 @@ require 'json'
 
 RSpec.describe 'CatalogController config', type: :request do
   before(:all) do
-    indexer = MarcIndexer.new
-    indexer.process(File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.marc.xml'))
+    Book.destroy_all
+    Entry.destroy_all
+    tei = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.tei.xml')
+    marc = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.marc.xml')
+    solr = RSolr.connect(url: Blacklight.connection_config[:url])
+    solr.add(Cicognara::TEIIndexer.new(tei, marc).solr_docs)
+    solr.commit
   end
   describe 'document stored fields' do
     let(:doc) { JSON.parse(response.body)['response']['document'] }

--- a/spec/requests/search_field_spec.rb
+++ b/spec/requests/search_field_spec.rb
@@ -3,6 +3,15 @@ require 'json'
 
 RSpec.describe 'Blacklight search fields', type: :request do
   let(:docs) { JSON.parse(response.body)['response']['docs'] }
+  before(:all) do
+    Book.destroy_all
+    Entry.destroy_all
+    tei = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.tei.xml')
+    marc = File.join(File.dirname(__FILE__), '..', 'fixtures', 'cicognara.marc.xml')
+    solr = RSolr.connect(url: Blacklight.connection_config[:url])
+    solr.add(Cicognara::TEIIndexer.new(tei, marc).solr_docs)
+    solr.commit
+  end
   it 'section head is searchable in all_fields' do
     get '/catalog.json?search_field=all_fields&q=Delle+belle+arti+in+generale'
     expect(docs.select { |d| d['id'] == '1' }.length).to eq 1

--- a/spec/tei_helper.rb
+++ b/spec/tei_helper.rb
@@ -1,2 +1,0 @@
-$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
-require 'cicognara/tei_indexer'


### PR DESCRIPTION
This makes it so that each Entry and Book knows how to create its own
solr document, outside the scope of the entire METS file. It should
allow us to update the index on a more atomic level when things like new
versions being added happen.

Closes #148, closes #149 