### PR TITLE
delete old solr index before adding new docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,13 @@ You can also specify an email address to make a particular user an amdin:
 ```
 EMAIL=user@example.org rake set_admin_role
 ```
+
+# Deploying:
+When deploying, make sure the desired cicognara-catalogo (MARC and TEI) release is specified:
+```
+# config/deploy.rb`
+set :default_env,
+    'MARCPATH' => 'public/cicognara.mrx.xml',
+    'TEIPATH' => 'public/catalogo.tei.xml',
+    'CATALOGO_VERSION' => 'v1.2'
+```

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,7 +30,7 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'vendor/bundle')
 set :default_env,
     'MARCPATH' => 'public/cicognara.mrx.xml',
     'TEIPATH' => 'public/catalogo.tei.xml',
-    'CATALOGO_VERSION' => 'v1.1'
+    'CATALOGO_VERSION' => 'v1.2'
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5

--- a/lib/tasks/tei.rake
+++ b/lib/tasks/tei.rake
@@ -7,6 +7,7 @@ namespace :tei do
     marcpath = ENV['MARCPATH'] || File.join(File.dirname(__FILE__), '../../', 'spec/fixtures', 'cicognara.marc.xml')
     solr_server = Blacklight.connection_config[:url]
     solr = RSolr.connect(url: solr_server)
+    solr.delete_by_query('*:*')
     solr.add(Cicognara::TEIIndexer.new(teipath, marcpath).solr_docs)
     solr.commit
   end


### PR DESCRIPTION
Clearing out the old Solr index shouldn't have any dire consequences if it is triggered on each deploy right?