### PR TITLE
allows marc records with multiple dclibs to index

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -205,6 +205,7 @@ class CatalogController < ApplicationController
       end
     end
     @linked_books.compact!
+    @linked_books.uniq!(&:_source) if @linked_books.length > 1
   end
 
   def has_search_parameters?

--- a/app/models/marc_indexer.rb
+++ b/app/models/marc_indexer.rb
@@ -227,8 +227,13 @@ class MarcIndexer < Blacklight::Marc::Indexer
     to_field 'edition_t', extract_marc('250ab')
 
     each_record do |record, context|
+      # keep id unique key single valued, but use alt_id to serve docs in Blacklight
+      id = context.output_hash['id']
+      context.output_hash['id'] = id[0..0]
+      context.output_hash['alt_id'] = id
+
       # add display fields
-      context.output_hash['dclib_display'] = context.output_hash['id']
+      context.output_hash['dclib_display'] = id
       context.output_hash['published_display'] = context.output_hash['published_t'] unless context.output_hash['published_t'].nil?
       context.output_hash['title_addl_display'] = context.output_hash['title_addl_t'] unless context.output_hash['title_addl_t'].nil?
       context.output_hash['title_added_entry_display'] = context.output_hash['title_added_entry_t'] unless context.output_hash['title_added_entry_t'].nil?

--- a/lib/cicognara/catalogo_item.rb
+++ b/lib/cicognara/catalogo_item.rb
@@ -26,7 +26,7 @@ module Cicognara
     end
 
     def doc_tei_fields
-      { id: n, cico_s: n, cico_sort: n, tei_description_unstem_search: text, tei_section_display: section_display,
+      { id: n, alt_id: n, cico_s: n, cico_sort: n, tei_description_unstem_search: text, tei_section_display: section_display,
         tei_section_head_italian: section_head, tei_section_number_display: section_number,
         tei_author_txt: item_authors, tei_pub_txt: item_pubs, tei_date_display: item_dates,
         tei_note_italian: item_notes, tei_title_txt: item_titles, tei_section_facet: section_display }

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -468,6 +468,7 @@
 
    <!-- NOTE: this is not a full list of fields in the index; dynamic fields are also used -->
    <field name="id" type="string" indexed="true" stored="true" required="true" />
+   <field name="alt_id" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="_version_" type="long" indexed="true" stored="true" multiValued="false" />
    <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
    <!-- default, catch all search field -->

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -295,7 +295,7 @@
       <str name="echoParams">all</str>
       <str name="fl">*</str>
       <str name="rows">1</str>
-      <str name="q">{!term f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
+      <str name="q">{!term f=alt_id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
     </lst>
   </requestHandler>
 

--- a/spec/cicognara/tei_indexer_spec.rb
+++ b/spec/cicognara/tei_indexer_spec.rb
@@ -21,13 +21,13 @@ describe Cicognara::TEIIndexer do
   describe '#books' do
     it 'builds the same index as if #to_solr was called' do
       expect(@subject.books[0].to_solr).to eq @subject.solr_docs[0]
-      expect(@subject.solr_docs[4]).to eq @subject.entries[1].to_solr
+      expect(@subject.solr_docs[5]).to eq @subject.entries[1].to_solr
     end
   end
 
   describe '#solr_docs' do
-    it 'has a length of 8' do
-      expect(@subject.solr_docs.length).to eq 8
+    it 'has a length of 10' do
+      expect(@subject.solr_docs.length).to eq 10
     end
   end
 end

--- a/spec/features/view_spec.rb
+++ b/spec/features/view_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe 'entry views', type: :feature do
     expect(page).not_to have_link 'Addito Libellus Compendiarum virtutis adipiscendæ ec. et carmina.'
   end
 
+  it 'displays marc info once when an entry dclib num matches twice on a single record' do
+    visit '/catalog/35'
+    expect(page.all('.linked-books').length).to eq 1
+  end
+
   describe 'a logged in user' do
     before do
       @user = stub_admin_user

--- a/spec/fixtures/cicognara.marc.xml
+++ b/spec/fixtures/cicognara.marc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<collection>
-  <record xmlns="http://www.loc.gov/MARC21/slim">
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
     <leader>01785cam a2200349 a 4500</leader>
     <controlfield tag="001">8524680</controlfield>
     <controlfield tag="005">20160419234839.0</controlfield>
@@ -111,7 +111,7 @@
       <subfield code="h">MICROFICHE 5</subfield>
     </datafield>
   </record>
-  <record xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
     <leader>01414cam a2200325 a 4500</leader>
     <controlfield tag="001">8524683</controlfield>
     <controlfield tag="005">20160420000226.0</controlfield>
@@ -207,7 +207,7 @@
       <subfield code="h">MICROFICHE 5</subfield>
     </datafield>
   </record>
-  <record xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
     <leader>01422cam a2200289 a 4500</leader>
     <controlfield tag="001">8524684</controlfield>
     <controlfield tag="005">20160420000226.0</controlfield>
@@ -295,6 +295,105 @@
     </datafield>
     <datafield ind1="8" ind2=" " tag="852">
       <subfield code="0">8271614</subfield>
+      <subfield code="b">safi</subfield>
+      <subfield code="h">MICROFICHE 5</subfield>
+    </datafield>
+  </record>
+  <record>
+    <leader>01479cam a2200313 a 4500</leader>
+    <controlfield tag="001">8544955</controlfield>
+    <controlfield tag="005">20170118151537.0</controlfield>
+    <controlfield tag="007">he|amu|||bacu</controlfield>
+    <controlfield tag="008">981022s1805    it      bb    000 0 ita d</controlfield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="9">0170-62260</subfield>
+    </datafield>
+    <datafield ind1="7" ind2=" " tag="024">
+      <subfield code="a">35</subfield>
+      <subfield code="2">cico</subfield>
+    </datafield>
+    <datafield ind1="7" ind2=" " tag="024">
+      <subfield code="a">cico:gzw</subfield>
+      <subfield code="2">dclib</subfield>
+    </datafield>
+    <datafield ind1="7" ind2=" " tag="024">
+      <subfield code="a">cico:vzk</subfield>
+      <subfield code="2">dclib</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(CStRLIN)DCNA98-B6678</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">207328</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">DNGA</subfield>
+      <subfield code="c">DNGA</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Ghiberti, Lorenzo,</subfield>
+      <subfield code="d">1378-1455.</subfield>
+      <subfield code="0">(uri)http://id.loc.gov/authorities/names/n78096136</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Commentario inedito di Lorenzo Ghiberti</subfield>
+      <subfield code="h">[microform] :</subfield>
+      <subfield code="b">estratto da manoscritti della Biblioteca Magliabecchiana.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">[S.l. :</subfield>
+      <subfield code="b">s.n.,</subfield>
+      <subfield code="c">1805]</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">38 p.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Fiche no. 35, copy 2 has BAV no. IVM36 (8)</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="504">
+      <subfield code="a">Includes bibliographical references.</subfield>
+    </datafield>
+    <datafield ind1="4" ind2=" " tag="510">
+      <subfield code="a">Cicognara,</subfield>
+      <subfield code="c">35</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="533">
+      <subfield code="a">Microfiche.</subfield>
+      <subfield code="b">Urbana, Ill. :</subfield>
+      <subfield code="c">Leopoldo Cicognara Program at the University of Illinois Library in Association with the Vatican Library ;</subfield>
+      <subfield code="b">Bassingbourn, Cambridgeshire, U.K. :</subfield>
+      <subfield code="c">Chadwyck-Healy Microform,</subfield>
+      <subfield code="d">1989- .</subfield>
+      <subfield code="e">1 microfiche : positive.</subfield>
+      <subfield code="f">(Cicognara Library)</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Art.</subfield>
+      <subfield code="0">(uri)http://id.loc.gov/authorities/subjects/sh85007461</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="710">
+      <subfield code="a">Fondo Cicognara (Biblioteca apostolica vaticana)</subfield>
+      <subfield code="0">(uri)http://id.loc.gov/authorities/names/nr94016468</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="710">
+      <subfield code="a">Leopoldo Cicognara Program (University of Illinois at Urbana-Champaign)</subfield>
+      <subfield code="0">(uri)http://id.loc.gov/authorities/names/nr94016472</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="830">
+      <subfield code="a">Cicognara library.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="902">
+      <subfield code="a">jwl</subfield>
+      <subfield code="b">z</subfield>
+      <subfield code="6">a</subfield>
+      <subfield code="7">m</subfield>
+      <subfield code="d">w</subfield>
+      <subfield code="f">0</subfield>
+      <subfield code="e">20140710</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="852">
+      <subfield code="0">8289598</subfield>
       <subfield code="b">safi</subfield>
       <subfield code="h">MICROFICHE 5</subfield>
     </datafield>

--- a/spec/fixtures/cicognara.tei.xml
+++ b/spec/fixtures/cicognara.tei.xml
@@ -150,6 +150,18 @@
 	      <note>Le stampe in legno di cui va adorno questo Libretto sono eleganti e singolari. 12 tav. oltre il frontispizio sono
 	      quelle del primo lib. e 21 sono quelle del secondo. Magnif. esemp.</note>
             </item>
+
+        <item xml:id="c1d1e1398" n="35" corresp="cico:gzw cico:vzk">
+          <label>35.</label>
+          <bibl>
+            <author>GHIBERTI (Lorenzo)</author>,
+            <title> Commentario inedito sulle arti estratto da manoscritti della Magliabechiana e pubblicato nel volume secondo della
+            Storia della scultura di L. Cicognara,</title>
+	        <pubPlace>Venezia</pubPlace>
+            <date>1805,</date>
+            <extent> in 8, M. 36.</extent>
+            </bibl>
+          </item>
 	  </list>
         </div>
         <div type="section" n="1.2">
@@ -158,7 +170,7 @@
 	  <fw type="head"/>
 	  <head><seg type="main">Della Pittura Trattati</seg></head>
 	  <list type="catalog">
-	    <item xml:id="c1d1e2260" n="66" corresp="cico:6gq">
+	    <item xml:id="c1d1e2260" n="66" corresp="cico:6gq cico:vzk">
               <label>66.</label> 
               <bibl>
                 <author>ALBERTI Leon Battista</author>, 

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe 'CatalogController config', type: :request do
     it 'stores dclib for display' do
       expect(doc['dclib_display']).to eq(['cico:m87'])
     end
+    describe 'multiple dclibs in single marc record' do
+      it 'multiple dclibs can display for a single marc record' do
+        get solr_document_path('cico:gzw'), as: :json
+        expect(doc['dclib_display']).to eq(['cico:gzw', 'cico:vzk'])
+      end
+      it 'document is retrieved on alt_id' do
+        get solr_document_path('cico:vzk'), as: :json
+        expect(doc['id']).to eq('cico:gzw')
+      end
+    end
   end
   describe 'index view' do
     it 'marc records do not appear in search results' do
@@ -45,6 +55,11 @@ RSpec.describe 'CatalogController config', type: :request do
         get solr_document_path('66'), as: :json
         dclib = JSON.parse(response.body)['response']['document']['dclib_s']
         expect(dclib).to include('cico:6gq')
+      end
+      it 'catalog item has alt_id field' do
+        get solr_document_path('66'), as: :json
+        dclib = JSON.parse(response.body)['response']['document']
+        expect(dclib['alt_id']).to include('66')
       end
       it 'catalog item renders without error' do
         get solr_document_path('66')


### PR DESCRIPTION
Adds a multivalued "alt_id" which is used to fetch catalogo entries and marc from Solr. Closes #219 