### PR TITLE
Use updated MARC/TEI data, preserve static pages across deployments

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ set :deploy_to, '/opt/cicognara'
 set :linked_files, fetch(:linked_files, []).push('config/secrets.yml')
 
 # Default value for linked_dirs is []
-set :linked_dirs, fetch(:linked_dirs, []).push('log', 'vendor/bundle')
+set :linked_dirs, fetch(:linked_dirs, []).push('app/views/pages/catalogo', 'log', 'vendor/bundle')
 
 # Default value for default_env is {}
 set :default_env,

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,7 +30,7 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'vendor/bundle')
 set :default_env,
     'MARCPATH' => 'public/cicognara.mrx.xml',
     'TEIPATH' => 'public/catalogo.tei.xml',
-    'CATALOGO_VERSION' => 'v2.0'
+    'CATALOGO_VERSION' => 'v2.0a'
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5

--- a/spec/models/marc_indexer_spec.rb
+++ b/spec/models/marc_indexer_spec.rb
@@ -91,4 +91,13 @@ RSpec.describe MarcIndexer, type: :model do
     expect(@values.first['related_name_display']).to be nil
     expect(@values[2]['related_name_display'].first).to eq 'Bogus place'
   end
+  it 'indexes Cicognara numbers from the 510 field' do
+    expect(@values[4]['cico_id_display']).to eq(%w[4716 4025])
+  end
+  it 'indexes note labels' do
+    expect(@values[4]['note_display']).to include('<strong>Fiche no.:</strong> 4716=4025.')
+  end
+  it 'indexes hierarchical places' do
+    expect(@values[4]['place_display']).to eq(['Germany—Bremen'])
+  end
 end


### PR DESCRIPTION
* Use updated MARC/TEI from https://github.com/pulibrary/cicognara-catalogo
* Link `app/views/pages/catalogo` directory to preserve generated pages across deploys

Fixes #317 