### PR TITLE
Removing Google font with diacritic spacing problems in favor of Helvetica

### DIFF
--- a/app/assets/stylesheets/components/_variables.scss
+++ b/app/assets/stylesheets/components/_variables.scss
@@ -6,7 +6,7 @@ $white: #fff;
 $lighter-gray: #fafafa;
 $light-gray: #efefef;
 
-$sans-serif: "Source Sans Pro", Helvetica, sans-serif;
+$sans-serif: Helvetica, sans-serif;
 $serif: "Cardo", Georgia, serif;
 $intro-heading: "Playfair Display", Georgia, serif;
 


### PR DESCRIPTION
In Firefox, Source Sans Pro has extra spacing after characters with diacritics, but Helvetica displays them correctly.

Fixes #278