### PR TITLE
Reordering facets, reworking digital content facet

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Naming/PredicateName:
 RSpec/AnyInstance:
   Exclude:
     - 'spec/support/**/*'
+    - 'spec/views/catalog/_index_links_default.html.erb_spec.rb'
 
 RSpec/DescribeClass:
   Exclude:

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,15 +71,15 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
+    config.add_facet_field 'name_facet', label: 'Name', limit: true
     config.add_facet_field 'pub_date', label: 'Publication Year', single: true, limit: true
-    config.add_facet_field 'subject_topic_facet', label: 'Topic', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'subject_era_facet', label: 'Era', limit: true
     config.add_facet_field 'language_facet', label: 'Language', limit: true
     config.add_facet_field 'subject_geo_facet', label: 'Region', limit: true
-    config.add_facet_field 'subject_era_facet', label: 'Era', limit: true
     config.add_facet_field 'subject_genre_facet', label: 'Genre', limit: true
-    config.add_facet_field 'name_facet', label: 'Name', limit: true
+    config.add_facet_field 'subject_topic_facet', label: 'Topic', limit: true, index_range: 'A'..'Z'
     config.add_facet_field 'subject_facet', label: 'Subject', show: false
-    config.add_facet_field 'tei_section_facet', label: 'Section', limit: true
+    config.add_facet_field 'tei_section_facet', label: 'Catalogo Section', limit: true
     config.add_facet_field 'contributing_library_facet', label: 'Contributing Library', limit: true
     config.add_facet_field 'digitized_version_available_facet', label: 'Digitized Version Available', limit: true
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -22,6 +22,6 @@ class Book < ActiveRecord::Base
 
   def digitized_version_available
     return ['None'] if versions.empty?
-    versions.map { |v| v.based_on_original? ? 'Microfiche' : 'Matching Copy' }
+    versions.map { |v| v.based_on_original? ? 'Microfiche' : 'Matching copy' }
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -15,12 +15,13 @@ class Book < ActiveRecord::Base
   def extra_solr
     {
       'contributing_library_facet' => contributing_libraries.map(&:label),
-      'digitized_version_available_facet' => [digitized_version_available?],
+      'digitized_version_available_facet' => digitized_version_available,
       'manifests_s' => versions.map(&:manifest)
     }
   end
 
-  def digitized_version_available?
-    versions.empty? ? 'No' : 'Yes'
+  def digitized_version_available
+    return ['None'] if versions.empty?
+    versions.map { |v| v.based_on_original? ? 'Microfiche' : 'Matching Copy' }
   end
 end

--- a/app/views/catalog/_index_links_default.html.erb
+++ b/app/views/catalog/_index_links_default.html.erb
@@ -1,5 +1,11 @@
 <div class="view-links col-md-12">
   <% counter = document_counter_with_offset(document_counter) %>
-    <%= link_to_document document, 'Catalog View', counter: counter, class: 'btn btn-xs btn-default' %>
-    <%= link_to 'Browse View', catalogo_link(document), class: 'btn btn-xs btn-default' %>
+    <%= link_to 'Browse full Catalogo', catalogo_link(document), class: 'btn btn-xs btn-default' %>
+    <% ['Microfiche', 'Matching Copy'].each do |val| %>
+      <% if document['digitized_version_available_facet']&.include?(val) %>
+        <span class="digitized-<%= val.downcase %> label label-<%= val == 'Microfiche' ? 'default' : 'success' %>">
+          <%= val %>
+        </span>
+      <% end %>
+    <% end %>
 </div>

--- a/app/views/catalog/_index_links_default.html.erb
+++ b/app/views/catalog/_index_links_default.html.erb
@@ -1,7 +1,7 @@
 <div class="view-links col-md-12">
   <% counter = document_counter_with_offset(document_counter) %>
     <%= link_to 'Browse full Catalogo', catalogo_link(document), class: 'btn btn-xs btn-default' %>
-    <% ['Microfiche', 'Matching Copy'].each do |val| %>
+    <% ['Microfiche', 'Matching copy'].each do |val| %>
       <% if document['digitized_version_available_facet']&.include?(val) %>
         <span class="digitized-<%= val.downcase %> label label-<%= val == 'Microfiche' ? 'default' : 'success' %>">
           <%= val %>

--- a/app/views/shared/_front_header.html.erb
+++ b/app/views/shared/_front_header.html.erb
@@ -20,7 +20,7 @@
             <h1>The Digital Cicognara Library <span class="small"><span class="italic">An</span> Open-Access Collection <span class="italic">of the</span> Early Literature of the Arts</span></h1>
             <div class="search-browse--home">
               <%= render_search_bar  %>
-              <%= link_to 'Browse the Catalogo', browse_catalogo_path, class: 'btn btn-primary browse-catalogo' %>
+              <%= link_to 'Browse full Catalogo', browse_catalogo_path, class: 'btn btn-primary browse-catalogo' %>
             </div>
           </div>
         </div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -22,6 +22,6 @@
 <div id="search-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="<%= container_classes %>">
     <%= render_search_bar  %>
-    <%= link_to 'Browse the Catalogo', browse_catalogo_path, class: 'btn btn-primary browse-catalogo' %>
+    <%= link_to 'Browse full Catalogo', browse_catalogo_path, class: 'btn btn-primary browse-catalogo' %>
   </div>
 </div>

--- a/lib/cicognara/catalogo_item.rb
+++ b/lib/cicognara/catalogo_item.rb
@@ -23,7 +23,8 @@ module Cicognara
     private
 
     def resolve_avail(arr)
-      (arr || []).include?('Yes') ? 'Yes' : 'No'
+      arr = (arr || []).flatten.uniq
+      arr.length == 1 ? arr : arr.reject { |v| v == 'None' }
     end
 
     def corresp

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'searching', type: :feature do
     expect(page).to have_link 'Example Library'
 
     expect(page).to have_selector 'h3.facet-field-heading', text: 'Digitized Version Available'
-    expect(page).to have_link 'Yes'
+    expect(page).to have_link 'Microfiche'
   end
 
   it 'suggests titles, authors, subjects and institutions, but not other fields' do

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe Book, type: :model do
       before do
         matching_version
       end
-      it 'indexes the manifest and digitized_version=Matching Copy' do
+      it 'indexes the manifest and digitized_version=Matching copy' do
         b = described_class.first
-        expect(b.to_solr['digitized_version_available_facet']).to contain_exactly('Matching Copy')
+        expect(b.to_solr['digitized_version_available_facet']).to contain_exactly('Matching copy')
         expect(b.to_solr['manifests_s']).to eq ['http://example.org/3.json']
       end
     end
@@ -86,9 +86,9 @@ RSpec.describe Book, type: :model do
         microfiche_version
         matching_version
       end
-      it 'indexes both manifests and digitized_version=Microfiche & Matching Copy' do
+      it 'indexes both manifests and digitized_version=Microfiche & Matching copy' do
         b = described_class.first
-        expect(b.to_solr['digitized_version_available_facet']).to contain_exactly('Microfiche', 'Matching Copy')
+        expect(b.to_solr['digitized_version_available_facet']).to contain_exactly('Microfiche', 'Matching copy')
         expect(b.to_solr['manifests_s']).to contain_exactly('http://example.org/2.json', 'http://example.org/3.json')
       end
     end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Entry, type: :model do
         end
 
         it 'has a digitized content' do
-          expect(subject.to_solr['digitized_version_available_facet']).to eq(['Matching Copy'])
+          expect(subject.to_solr['digitized_version_available_facet']).to eq(['Matching copy'])
         end
       end
       context 'when corresp has 2 values' do

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Entry, type: :model do
         end
 
         it 'has a digitized content' do
-          expect(subject.to_solr['digitized_version_available_facet']).to eq('Yes')
+          expect(subject.to_solr['digitized_version_available_facet']).to eq(['Matching Copy'])
         end
       end
       context 'when corresp has 2 values' do

--- a/spec/views/catalog/_index_links_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_links_default.html.erb_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'catalog/_index_links_default.html.erb' do
+  let(:base_doc) { { id: '1', tei_section_number_display: ['1.2'] } }
+
+  before do
+    allow_any_instance_of(Blacklight::CatalogHelperBehavior).to receive(:document_counter_with_offset).and_return(4)
+    render partial: 'catalog/index_links_default', locals: { document: document, document_counter: 4 }
+  end
+
+  context 'when there is no digitized copy' do
+    let(:document) { base_doc.merge(digitized_version_available_facet: ['None']).stringify_keys }
+
+    it 'does not have a badge' do
+      expect(rendered).not_to have_selector '.digitized-matching'
+      expect(rendered).not_to have_selector '.digitized-microfiche'
+    end
+  end
+  context 'when there is a microfiche copy' do
+    let(:document) { base_doc.merge(digitized_version_available_facet: ['Microfiche']).stringify_keys }
+
+    it 'has a only Microfiche badge' do
+      expect(rendered).to have_selector '.digitized-microfiche', text: 'Microfiche'
+      expect(rendered).not_to have_selector '.digitized-matching'
+    end
+  end
+  context 'when there is a matching copy' do
+    let(:document) { base_doc.merge(digitized_version_available_facet: ['Matching Copy']).stringify_keys }
+
+    it 'has a only Microfiche badge' do
+      expect(rendered).to have_selector '.digitized-matching', text: 'Matching Copy'
+      expect(rendered).not_to have_selector '.digitized-microfiche'
+    end
+  end
+  context 'when there is a matching copy' do
+    let(:document) { base_doc.merge(digitized_version_available_facet: ['Microfiche', 'Matching Copy']).stringify_keys }
+
+    it 'has both Matching and Microfiche badges' do
+      expect(rendered).to have_selector '.digitized-matching', text: 'Matching Copy'
+      expect(rendered).to have_selector '.digitized-microfiche', text: 'Microfiche'
+    end
+  end
+end

--- a/spec/views/catalog/_index_links_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_links_default.html.erb_spec.rb
@@ -25,18 +25,18 @@ RSpec.describe 'catalog/_index_links_default.html.erb' do
     end
   end
   context 'when there is a matching copy' do
-    let(:document) { base_doc.merge(digitized_version_available_facet: ['Matching Copy']).stringify_keys }
+    let(:document) { base_doc.merge(digitized_version_available_facet: ['Matching copy']).stringify_keys }
 
     it 'has a only Microfiche badge' do
-      expect(rendered).to have_selector '.digitized-matching', text: 'Matching Copy'
+      expect(rendered).to have_selector '.digitized-matching', text: 'Matching copy'
       expect(rendered).not_to have_selector '.digitized-microfiche'
     end
   end
   context 'when there is a matching copy' do
-    let(:document) { base_doc.merge(digitized_version_available_facet: ['Microfiche', 'Matching Copy']).stringify_keys }
+    let(:document) { base_doc.merge(digitized_version_available_facet: ['Microfiche', 'Matching copy']).stringify_keys }
 
     it 'has both Matching and Microfiche badges' do
-      expect(rendered).to have_selector '.digitized-matching', text: 'Matching Copy'
+      expect(rendered).to have_selector '.digitized-matching', text: 'Matching copy'
       expect(rendered).to have_selector '.digitized-microfiche', text: 'Microfiche'
     end
   end


### PR DESCRIPTION
* Facets ordered in desired order of metadata display
* Digital Content facet now has Microfiche/Matching/None options

Fixes #300, Fixes #301, Fixes #302, Fixes #303 