### PR TITLE
Updates rack to 2.0.6 and loofah to 2.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,10 +55,10 @@ group :development do
 end
 
 group :development, :test do
-  gem 'simplecov', '~> 0.9', require: false
-  gem 'rails-controller-testing'
   gem 'pry-rails'
   gem 'pry-byebug'
+  gem 'rails-controller-testing'
+  gem 'simplecov', '~> 0.9', require: false
 end
 
 group :test do
@@ -67,18 +67,20 @@ group :test do
 end
 
 gem 'bixby'
-gem 'rsolr', '~> 1.0'
+gem 'blacklight-marc', '~> 6.0'
 gem 'cancancan', '~> 1.10'
 gem 'devise'
 gem 'devise-guests', '~> 0.6.1'
-gem 'blacklight-marc', '~> 6.0'
-gem 'solr_wrapper', '~> 2.0.0'
-gem 'traject'
 gem 'high_voltage', '~> 3.0.0'
-gem 'validate_url'
-gem 'pul_uv_rails', github: 'pulibrary/pul_uv_rails'
 gem 'iiif-presentation'
+gem 'loofah', '>= 2.2.3'
 gem 'nokogiri', '~> 1.8.1'
 gem 'omniauth', '~> 1.8.1'
 gem 'omniauth-google-oauth2'
+gem 'pul_uv_rails', github: 'pulibrary/pul_uv_rails'
+gem 'rsolr', '~> 1.0'
+gem 'solr_wrapper', '~> 2.0.0'
+gem 'rack', '>= 2.0.6'
 gem 'rubyzip', '>= 1.2.2'
+gem 'traject'
+gem 'validate_url'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     library_stdnums (1.4.1)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -214,7 +214,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
@@ -382,6 +382,7 @@ DEPENDENCIES
   iiif-presentation
   jbuilder (~> 2.7.0)
   jquery-rails
+  loofah (>= 2.2.3)
   nokogiri (~> 1.8.1)
   omniauth (~> 1.8.1)
   omniauth-google-oauth2
@@ -389,6 +390,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   pul_uv_rails!
+  rack (>= 2.0.6)
   rails (~> 5.1.6)
   rails-controller-testing
   rsolr (~> 1.0)


### PR DESCRIPTION
Addresses [CVE-2018-16470](https://nvd.nist.gov/vuln/detail/CVE-2018-16470), [CVE-2018-16471](https://nvd.nist.gov/vuln/detail/CVE-2018-16471), and [CVE-2018-16468](https://nvd.nist.gov/vuln/detail/CVE-2018-16468)