### PR TITLE
Separate deploy from reindexing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
+    json (1.8.6)
     jwt (1.5.6)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
@@ -409,4 +409,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.4

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -41,7 +41,8 @@ set :passenger_restart_with_touch, true
 set :passenger_restart_with_touch, true
 
 namespace :deploy do
-  after :restart, :clear_cache do
+  desc 'Reindex and generate partials'
+  task :reindex do
     on roles(:web), in: :groups, limit: 3, wait: 5 do
       within release_path do
         execute :rake, 'tei:deploy'


### PR DESCRIPTION
Creates new Capistrano task to separate reindexing from the deployment.
Invoked with `cap production deploy:reindex`.

Closes #235 