### PR TITLE
Updates the Capistrano deployment configuration and tasks for the production environment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,6 +42,7 @@ namespace :deploy do
   task :reindex do
     on roles(:web), in: :groups, limit: 3, wait: 5 do
       within release_path do
+        execute :rake, 'tei:catalogo:update'
         execute :rake, 'tei:index'
       end
     end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,3 +1,3 @@
-server 'cicognara.princeton.edu', user: 'deploy', roles: %w(app db web)
-set :deploy_to, '/opt/rails_app/'
+server 'cicognara1.princeton.edu', user: 'deploy', roles: %w(app db web)
+set :deploy_to, '/opt/cicognara/'
 set :default_env, fetch(:default_env).merge('RAILS_ENV' => 'production')

--- a/lib/tasks/tei.rake
+++ b/lib/tasks/tei.rake
@@ -1,6 +1,17 @@
 require 'cicognara/tei_indexer'
 
 namespace :tei do
+  namespace :catalogo do
+    desc 'Pulls in the Catalogo TEI and MARC'
+    task :update do
+      teipath = ENV['TEIPATH'] || File.join(File.dirname(__FILE__), '..', '..', 'public', 'cicognara.tei.xml')
+      marcpath = ENV['MARCPATH'] || File.join(File.dirname(__FILE__), '..', '..', 'public', 'cicognara.mrx.xml')
+      catalogo_version = ENV['CATALOGO_VERSION'] || 'master'
+      `wget https://raw.githubusercontent.com/pulibrary/cicognara-catalogo/#{catalogo_version}/catalogo.tei.xml -O #{teipath}`
+      `wget https://raw.githubusercontent.com/pulibrary/cicognara-catalogo/#{catalogo_version}/cicognara.mrx.xml -O #{marcpath}`
+    end
+  end
+
   desc 'index solr documents from path to document at TEIPATH and MARCPATH.'
   task index: :environment do
     teipath = ENV['TEIPATH'] || File.join(File.dirname(__FILE__), '../../', 'spec/fixtures', 'cicognara.tei.xml')
@@ -27,8 +38,7 @@ namespace :tei do
 
   desc 'Pulls catalogo tei/marc then indexes and generates partials'
   task :deploy do
-    `wget https://raw.githubusercontent.com/pulibrary/cicognara-catalogo/#{ENV['CATALOGO_VERSION']}/catalogo.tei.xml -O #{ENV['TEIPATH']}`
-    `wget https://raw.githubusercontent.com/pulibrary/cicognara-catalogo/#{ENV['CATALOGO_VERSION']}/cicognara.mrx.xml -O #{ENV['MARCPATH']}`
+    Rake::Task['tei:catalogo:update'].invoke
     Rake::Task['tei:index'].invoke
     Rake::Task['tei:partials'].invoke
   end


### PR DESCRIPTION
Relates to #338 and addresses the following:
- Separates the Rake task for downloading catalogo TEI and MARC into the `tei:catalogo:update` task
- Ensures that the Capistrano task `deploy:reindex` downloads the catalogo first before indexing
- Updates the production server and deployment directory