### PR TITLE
Resolves a styling bug rendering the facet panel under the footer

### DIFF
--- a/app/assets/stylesheets/components/_facets.scss
+++ b/app/assets/stylesheets/components/_facets.scss
@@ -25,6 +25,7 @@
   }
 
   #facet-panel-collapse.affix {
+    z-index: 1;
     top: 30px;
 
     @media (min-width: 768px) {


### PR DESCRIPTION
This proposes to resolve a bug found when users expand facet panels: https://cicognara.org/catalog?q=&search_field=all_fields

<img width="528" alt="catalog-facets-z-index_screenshot_0" src="https://user-images.githubusercontent.com/1443986/53739542-01d48c00-3e60-11e9-87e5-dba97c3e0b7c.png">

<img width="516" alt="catalog-facets-z-index_screenshot_1" src="https://user-images.githubusercontent.com/1443986/53739548-0436e600-3e60-11e9-9bf8-b0a13cbf1412.png">
