### PR TITLE
Updating FAQ and metadata checklist

### DIFF
--- a/app/views/pages/checklist.html.erb
+++ b/app/views/pages/checklist.html.erb
@@ -49,25 +49,28 @@
       </thead>
       <tbody>
         <tr>
-          <th scope="row">IIIF Manifest	856</th>
-          <td>856 41 $u [URI]</td>
+          <th scope="row">IIIF Manifest</th>
+          <td>
+            <div>856 41 $u [Manifest URI]</div>
+            <div>$q JSON (IIIF Manifest)</div>
+          </td>
           <td>
             <div>&lt;relatedItem type="otherFormat"&gt;</div>
             <div>&nbsp;&nbsp;&lt;identifier type="uri"&gt;</div>
-            <div>&nbsp;&nbsp;&nbsp;&nbsp;[URI]</div>
+            <div>&nbsp;&nbsp;&nbsp;&nbsp;[Manifest URI]</div>
             <div>&nbsp;&nbsp;&lt;/identifier&gt;</div>
             <div>&lt;/relatedItem&gt;</div>
           </td>
           <td>
             <div>&lt;dc:hasFormat&gt;</div>
-            <div>&nbsp;&nbsp;[URI]</div>
+            <div>&nbsp;&nbsp;[Manifest URI]</div>
             <div>&lt;/dc:hasFormat&gt;</div>
           </td>
           <td>IIIF Manifest URL</td>
         </tr>
         <tr>
           <th scope="row">DCL Number (DCL#)</th>
-          <td>024 8_ $a dcl:xyz 	</td>
+          <td>024 8_ $a dcl:xyz</td>
           <td>
             <div>&lt;mods:identifier type="local"&gt;</div>
             <div>&nbsp;&nbsp;dcl:xyz</div>
@@ -190,6 +193,12 @@
           }
        ],
     </pre>
+
+    <p>Manifests can be checked in the <%= link_to "IIIF Presentation API Validator",
+      "https://iiif.io/api/presentation/validator/service/" %> to determine whether they have been configured
+      correctly according to IIIF specifications. The manifest should generate no errors and minimal warnings
+      when run through the Validator.</p>
+
     <p class="bold-text">
       Send source metadata to the Getty Research Portal (<%= mail_to "portal@getty.edu" %>)
       via one of the following methods:
@@ -199,8 +208,7 @@
       <li>
         OAI harvest or API - One-time email with link to OAI or API repository which will be harvested quarterly unless asked otherwise.
       </li>
-      <li>FTP</li>
-      <li>Please email portal@getty.edu if none of the above methods are possible and we will work with you on</li> transmitting files.
-
+      <li>Please email portal@getty.edu if none of the above methods are possible and we will work with you on transmitting files.</li>
+    </ul>
   </div>
 </section>

--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -193,12 +193,11 @@
       <ul class="normal-size-text">
         <li>Email attachment</li>
         <li>Open Archives Initiative (OAI) harvest</li>
-        <li>Institution API</li>
       </ul>
       <p>
         <span class="bold-text">*Please note:</span> If your institution is not using
-        an OAI-repository or API, and changes or updates its source metadata, please
-        send an updated file to the Getty Research Portal.
+        an OAI-repository, and changes or updates its source metadata, please send an updated
+        file to the Getty Research Portal.
       </p>
     </div>
     <div class="question-text">
@@ -238,20 +237,21 @@
       <table class="table table-bordered">
         <td>
           <div class="bold-text">MARC</div>
-          <div>856 41 $u [URI]</div>
+          <div>856 41 $u [Manifest URI]</div>
+          <div>$q JSON (IIIF Manifest)</div>
         </td>
         <td>
        	  <div class="bold-text">MODS</div>
           <div>&lt;relatedItem type="otherFormat"&gt;</div>
           <div>&nbsp;&nbsp;&lt;identifier type="uri"&gt;</div>
-          <div>&nbsp;&nbsp;&nbsp;&nbsp;[URI]</div>
+          <div>&nbsp;&nbsp;&nbsp;&nbsp;[Manifest URI]</div>
           <div>&nbsp;&nbsp;&lt;/identifier&gt;</div>
           <div>&lt;/relatedItem&gt;</div>
         </td>
         <td>
           <div class="bold-text">Dublin Core</div>
           <div>&lt;dc:hasFormat&gt;</div>
-          <div>&nbsp;&nbsp;[URI]</div>
+          <div>&nbsp;&nbsp;[Manifest URI]</div>
           <div>&lt;/dc:hasFormat&gt;</div>
         </td>
         <td>
@@ -278,12 +278,17 @@
       <p>
         <div class="normal-size-text">
           Please find an example for a IIIF manifest in the Digital Cicognara Library project
-          here:
-        </div>
-        <div class="normal-size-text">
-        <%= link_to nil, "https://digi.ub.uni-heidelberg.de/diglit/iiif/junius1694/manifest.json" %>
+          here: <%= link_to nil, "https://digi.ub.uni-heidelberg.de/diglit/iiif/junius1694/manifest.json" %>
         </div>
       </p>
+      <p>
+        <div class="normal-size-text">
+          Manifests can be checked in the <%= link_to "IIIF Presentation API Validator",
+          "https://iiif.io/api/presentation/validator/service/" %> to determine whether they have
+          been configured correctly according to IIIF specifications. The manifest should generate
+          no errors and minimal warnings when run through the Validator.
+        </div>
+      <p>
     </div>
     <div class="question-text">
       <a role="button" class="collapsed" data-toggle="collapse" href="#collapseNine" aria-expanded="false" aria-controls="collapseNine">


### PR DESCRIPTION
* Using "Manifest URI" instead of "URI"
* Linking to IIIF manifest validator
* Removing FTP as option for sending data to Getty

Fixes #351 