### PR TITLE
Extends two templates to process prefaces as well as sections.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,7 +27,7 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'vendor/bundle')
 set :default_env,
     'MARCPATH' => 'public/cicognara.mrx.xml',
     'TEIPATH' => 'public/catalogo.tei.xml',
-    'CATALOGO_VERSION' => 'v2.1'
+    'CATALOGO_VERSION' => 'v2.2'
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5

--- a/lib/xsl/partials-section.xsl
+++ b/lib/xsl/partials-section.xsl
@@ -19,7 +19,7 @@
     <xsl:template match="tei:teiCorpus" mode="toc">
         <xsl:param name="current-item-number"/>
         <ol class="toc">
-            <xsl:for-each select="//tei:div[@type = 'section']">
+            <xsl:for-each select="//tei:div[@type = ['section', 'preface']]">
                 <li>
                     <xsl:if test="$current-item-number eq @n">
                         <xsl:attribute name="class">current</xsl:attribute>
@@ -40,7 +40,7 @@
         </ol>
     </xsl:template>
 
-    <xsl:template match="tei:div[@type = 'section']">
+    <xsl:template match="tei:div[@type = ['section', 'preface']]">
         <xsl:result-document exclude-result-prefixes="#all" method="xml"
             href="{$path_to_partials}/section_{@n}.html">
             <div class="container">
@@ -77,7 +77,6 @@
         </xsl:result-document>
     </xsl:template>
 
-
     <xsl:template match="tei:pb[@type = 'cico']">
         <span class="catalogo-pb" id="page_{@n}">
             <xsl:value-of select="@n"/>
@@ -92,6 +91,7 @@
         </head>
     </xsl:template>
 
+<!-- Why are this section's subheads special? -->
     <xsl:template match="tei:div[@n = '2.13']/tei:div/tei:head">
         <head>
             <h2>
@@ -126,22 +126,24 @@
         </span>
     </xsl:template>
 
-
     <xsl:template match="tei:bibl">
         <span class="catalogo-bibl">
             <xsl:apply-templates/>
         </span>
     </xsl:template>
+
     <xsl:template match="tei:author">
         <span class="catalogo-author">
             <xsl:apply-templates/>
         </span>
     </xsl:template>
+
     <xsl:template match="tei:note">
         <div class="catalogo-note">
             <xsl:apply-templates/>
         </div>
     </xsl:template>
+
     <xsl:template match="tei:title">
         <span class="catalogo-title">
             <a class="catalog-link" href="/{$url_path_prefix}catalog/{./ancestor::tei:item/@n}">
@@ -149,21 +151,25 @@
             </a>
         </span>
     </xsl:template>
+
     <xsl:template match="tei:pubPlace">
         <span class="catalogo-pubPlace">
             <xsl:apply-templates/>
         </span>
     </xsl:template>
+
     <xsl:template match="tei:date">
         <span class="catalogo-date">
             <xsl:apply-templates/>
         </span>
     </xsl:template>
+    
     <xsl:template match="tei:extent">
         <span class="catalogo-extent">
             <xsl:apply-templates/>
         </span>
     </xsl:template>
+    
     <xsl:template match="tei:p">
         <p>
             <xsl:apply-templates/>

--- a/lib/xsl/partials-section.xsl
+++ b/lib/xsl/partials-section.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    exclude-result-prefixes="#all" version="2.0">
+    exclude-result-prefixes="tei xsl xs xd" version="1.0">
     <xd:doc scope="stylesheet">
         <xd:desc>
             <xd:p><xd:b>Created on:</xd:b> Aug 29, 2016</xd:p>
@@ -19,7 +19,7 @@
     <xsl:template match="tei:teiCorpus" mode="toc">
         <xsl:param name="current-item-number"/>
         <ol class="toc">
-            <xsl:for-each select="//tei:div[@type = ['section', 'preface']]">
+            <xsl:for-each select="//tei:div[@type = 'section' or @type = 'preface']">
                 <li>
                     <xsl:if test="$current-item-number eq @n">
                         <xsl:attribute name="class">current</xsl:attribute>
@@ -40,7 +40,7 @@
         </ol>
     </xsl:template>
 
-    <xsl:template match="tei:div[@type = ['section', 'preface']]">
+    <xsl:template match="tei:div[@type = 'section' or @type = 'preface']">
         <xsl:result-document exclude-result-prefixes="#all" method="xml"
             href="{$path_to_partials}/section_{@n}.html">
             <div class="container">


### PR DESCRIPTION
I added type attributes to the preface divs in `cicognara-catalogo/catalogo.tei.xml` (type="preface") and then modified two templates to process preface divs as well as section divs.
