### PR TITLE
Move solr deletion out of tei:index

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ require 'solr_wrapper/rake_task'
 desc 'Run Solr and Blacklight for interactive development'
 task :server, [:rails_server_args] do |_t, args|
   SolrWrapper.wrap do |solr|
-    solr.with_collection(name: 'cicognara', dir: File.join(File.expand_path(File.dirname(__FILE__)), 'solr', 'config')) do
+    solr.with_collection(name: 'cicognara', dir: File.join(File.expand_path(File.dirname(__FILE__)), 'solr', 'config'), persist: true) do
       puts 'Indexing TEI...'
       Rake::Task['tei:index'].invoke
       puts 'Generating partials...'

--- a/lib/tasks/tei.rake
+++ b/lib/tasks/tei.rake
@@ -12,13 +12,17 @@ namespace :tei do
     end
   end
 
+  desc 'delete solr index'
+  task clean_solr: :environment do
+    solr.delete_by_query('*:*')
+  end
+
   desc 'index solr documents from path to document at TEIPATH and MARCPATH.'
   task index: :environment do
     teipath = ENV['TEIPATH'] || File.join(File.dirname(__FILE__), '../../', 'spec/fixtures', 'cicognara.tei.xml')
     marcpath = ENV['MARCPATH'] || File.join(File.dirname(__FILE__), '../../', 'spec/fixtures', 'cicognara.marc.xml')
     solr_server = Blacklight.connection_config[:url]
     solr = RSolr.connect(url: solr_server)
-    solr.delete_by_query('*:*')
     solr.add(Cicognara::TEIIndexer.new(teipath, marcpath).solr_docs)
     solr.commit
   end
@@ -39,6 +43,7 @@ namespace :tei do
   desc 'Pulls catalogo tei/marc then indexes and generates partials'
   task :deploy do
     Rake::Task['tei:catalogo:update'].invoke
+    Rake::Task['clean_solr'].invoke
     Rake::Task['tei:index'].invoke
     Rake::Task['tei:partials'].invoke
   end


### PR DESCRIPTION
Add it back separately in deploy task.
Also set server task to run solr_wrapper with persist: true

Now our dev indexes should persist between runs of the server task

fixes #402