### PR TITLE
Fixes #436

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
     $(".uv").attr("data-uri", $(this).attr("data-manifest-uri"))
     $("*[data-manifest-uri]").parent().removeClass("active")
     $(this).parent().addClass("active")
-    version_id = $(this).attr("data-version-id")
+    version_id = $(this).parent().attr("data-version-id")
     $(".linked-books").hide()
     $("#" + version_id).show()
     document.location.hash = ''

--- a/app/views/catalog/_universal_viewer_default.html.erb
+++ b/app/views/catalog/_universal_viewer_default.html.erb
@@ -4,7 +4,8 @@
       <ul class="nav nav-pills nav-stacked" id="manifest-tabs">
         <% document.books.to_a.each_with_index do |book, b_index| %>
           <% book.versions.to_a.each_with_index do |version, v_index| %>
-            <li <%= 'class="active"'.html_safe if (b_index == 0 && v_index ==0) %>>
+              <li data-version-id="version_<%= version.id %>"
+		  <%= 'class="active"'.html_safe if (b_index == 0 && v_index ==0) %>>
               <a href="#" data-manifest-uri='<%= version.manifest %>'>
                 <%= version.based_on_original? ? 'Microfiche' : 'Matching Copy' %> (<%= book.digital_cico_number %>)<br/>
                 <span class="contrib"><%= version.contributing_library.label %></span>

--- a/app/views/catalog/_universal_viewer_default.html.erb
+++ b/app/views/catalog/_universal_viewer_default.html.erb
@@ -4,8 +4,7 @@
       <ul class="nav nav-pills nav-stacked" id="manifest-tabs">
         <% document.books.to_a.each_with_index do |book, b_index| %>
           <% book.versions.to_a.each_with_index do |version, v_index| %>
-              <li data-version-id="version_<%= version.id %>"
-		  <%= 'class="active"'.html_safe if (b_index == 0 && v_index ==0) %>>
+            <li data-version-id="version_<%= version.id %>" <%= 'class="active"'.html_safe if (b_index == 0 && v_index ==0) %>>
               <a href="#" data-manifest-uri='<%= version.manifest %>'>
                 <%= version.based_on_original? ? 'Microfiche' : 'Matching Copy' %> (<%= book.digital_cico_number %>)<br/>
                 <span class="contrib"><%= version.contributing_library.label %></span>

--- a/spec/views/catalog/_universal_viewer_default.html.erb_spec.rb
+++ b/spec/views/catalog/_universal_viewer_default.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'catalog/_universal_viewer_default.html.erb' do
   let(:book) { instance_double(Book, versions: [version], digital_cico_number: 'dcl:xyz') }
   let(:book2) { instance_double(Book, versions: [], digital_cico_number: 'dcl:abc') }
   let(:contributing_library) { instance_double(ContributingLibrary, label: 'Princeton University Library') }
-  let(:version) { instance_double(Version, manifest: manifests.first, label: 'Best Copy', contributing_library: contributing_library, based_on_original?: false) }
+  let(:version) { instance_double(Version, manifest: manifests.first, label: 'Best Copy', contributing_library: contributing_library, based_on_original?: false, id: '12345') }
 
   context 'when the document has no manifests' do
     before do


### PR DESCRIPTION
Adds a data-version-id attribute on the manifest tabs and properly retrieves it in the toggle code.