### PR TITLE
Getty Import should only reindex books.

### DIFF
--- a/app/services/getty_parser/importer.rb
+++ b/app/services/getty_parser/importer.rb
@@ -25,9 +25,8 @@ class GettyParser
     end
 
     def reindex!
-      entry_indexer = Cicognara::BulkEntryIndexer.new(Entry.all)
       book_documents = Book.includes(:versions, :contributing_libraries).all.map(&:to_solr)
-      solr.add(entry_indexer.entry_documents + book_documents)
+      solr.add(book_documents)
       solr.commit
     end
 


### PR DESCRIPTION
If it reindexes Entries without the TEI it breaks all the MARC displays.