### PR TITLE
Getty Import should reindex only Entries + Books that have versions.

### DIFF
--- a/app/services/getty_parser/importer.rb
+++ b/app/services/getty_parser/importer.rb
@@ -25,9 +25,9 @@ class GettyParser
     end
 
     def reindex!
-      entry_indexer = Cicognara::BulkEntryIndexer.new(Entry.all)
-      book_documents = Book.includes(:versions, :contributing_libraries).all.map(&:to_solr)
-      solr.add(entry_indexer.entry_documents + book_documents)
+      version_entries = Version.includes(book: [{ entries: :books }, :contributing_libraries, :versions]).map(&:book).flat_map(&:entries)
+      bulk_indexer = Cicognara::BulkEntryIndexer.new(version_entries)
+      solr.add(bulk_indexer.book_documents + bulk_indexer.entry_documents)
       solr.commit
     end
 


### PR DESCRIPTION
Entries have to be reindexed with Books or it breaks the MARC display,
and there's no reason to reindex items that don't have versions.