### PR TITLE
Speed up Getty reindexing.

### DIFF
--- a/app/services/getty_parser/importer.rb
+++ b/app/services/getty_parser/importer.rb
@@ -25,9 +25,8 @@ class GettyParser
     end
 
     def reindex!
-      entry_indexer = Cicognara::BulkEntryIndexer.new(Entry.all)
-      book_documents = Book.includes(:versions, :contributing_libraries).all.map(&:to_solr)
-      solr.add(entry_indexer.entry_documents + book_documents)
+      entry_indexer = Cicognara::BulkEntryIndexer.new(Entry.all.to_a)
+      solr.add(entry_indexer.book_documents + entry_indexer.entry_documents)
       solr.commit
     end
 

--- a/spec/services/getty_parser_spec.rb
+++ b/spec/services/getty_parser_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe GettyParser do
     it 'imports a version for a matching book with a DCL number' do
       stub_manifest('https://digi.ub.uni-heidelberg.de/diglit/iiif/ripa1613bd1/manifest.json', manifest_file: '4.json')
       book = Book.create!(digital_cico_number: 'dcl:srq')
+      Entry.create!(books: [book])
 
       described_class.new.import!
 
@@ -59,6 +60,7 @@ RSpec.describe GettyParser do
       stub_manifest('https://digi.ub.uni-heidelberg.de/diglit/iiif/ripa1613bd1/manifest.json', manifest_file: '4.json')
       stub_manifest('http://example.org/4.json')
       book = Book.create!(digital_cico_number: 'dcl:srq')
+      Entry.create!(books: [book])
       contrib = ContributingLibrary.find_or_create_by! label: 'Example Library', uri: 'http://example.org'
       Version.create! contributing_library: contrib, book: book,
                       label: 'version 2', based_on_original: false, owner_system_number: '1234',
@@ -82,7 +84,8 @@ RSpec.describe GettyParser do
       before do
         allow(Version).to receive(:find_or_initialize_by).and_return(version)
         allow(version).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
-        Book.create!(digital_cico_number: 'dcl:srq')
+        book = Book.create!(digital_cico_number: 'dcl:srq')
+        Entry.create!(books: [book])
       end
       it 'handles invalid version' do
         stub_manifest('https://digi.ub.uni-heidelberg.de/diglit/iiif/ripa1613bd1/manifest.json', manifest_file: '4.json')


### PR DESCRIPTION
The previous method didn't run traject over all books at once.