### PR TITLE
Use Solr8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,19 +5,24 @@ jobs:
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      SOLR_URL: "http://solr:SolrRocks@127.0.0.1:8888/solr/cicognara"
     docker:
       - image: circleci/ruby:2.6-node-browsers
         environment:
           RAILS_ENV: test
           CICOGNARA_DB_HOST: localhost
           CICOGNARA_DB_USERNAME: cicognara
+      - image: zookeeper:3.4
       - image: postgres:10.3-alpine
         environment:
           POSTGRES_USER: cicognara
           POSTGRES_DB: cicognara_test
           POSTGRES_PASSWORD: ""
-      - image: solr:7.7-alpine
-        command: bin/solr -cloud -noprompt -f -p 8888
+      - image: solr:8.4
+        command:
+          - "sh"
+          - "-c"
+          - wget -O /tmp/security.json "https://gist.githubusercontent.com/eliotjordan/a27be341dc2e7a532bad99203e0f55b7/raw/5866efab9242f953764c1b03d17763309e22948f/security.json" && server/scripts/cloud-scripts/zkcli.sh -zkhost localhost:2181 -cmd putfile /security.json /tmp/security.json && bin/solr -cloud -noprompt -f -p 8888 -z localhost:2181
     steps: &test_steps
       - checkout
       - run:
@@ -52,8 +57,8 @@ jobs:
           command: |
             cd solr/config
             zip -1 -r solr_config.zip ./*
-            curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://localhost:8888/solr/admin/configs?action=UPLOAD&name=cicognara"
-            curl -H 'Content-type: application/json' http://localhost:8888/api/collections/ -d '{create: {name: cicognara, config: cicognara, numShards: 1}}'
+            curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@127.0.0.1:8888/solr/admin/configs?action=UPLOAD&name=cicognara"
+            curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8888/api/collections/ -d '{create: {name: cicognara, config: cicognara, numShards: 1}}'
 
       # Cache Dependencies
       - type: cache-save

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,13 +1,13 @@
 name: cicognara
 services:
   cicognara_test_solr:
-    type: solr:7
+    type: solr:8.4
     portforward: true
     core: cicognara
     config:
       dir: solr/config
   cicognara_development_solr:
-    type: solr:7
+    type: solr:8.4
     portforward: true
     core: cicognara
     config:

--- a/app/models/marc_indexer.rb
+++ b/app/models/marc_indexer.rb
@@ -63,6 +63,15 @@ class MarcIndexer < Blacklight::Marc::Indexer
 
       # configurable logging, quiet by default
       provide 'log.level', ENV['TRAJECT_LOG_LEVEL'] || 'warn'
+      if c = Blacklight.connection_config
+        url = URI.parse(c[:url])
+        if url.user
+          client = HTTPClient.new
+          client.set_auth(c[:url], url.user, url.password)
+          provide "solr_json_writer.http_client", client
+        end
+        provide "solr.url", c[:url]
+      end
     end
 
     to_field 'id' do |record, accumulator|

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -317,7 +317,6 @@
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
-        <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
@@ -326,7 +325,6 @@
     <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
        <analyzer>
           <tokenizer class="solr.KeywordTokenizerFactory"/>
-          <filter class="solr.StandardFilterFactory"/>
           <filter class="solr.LowerCaseFilterFactory"/>
           <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
        </analyzer>


### PR DESCRIPTION
Using Solr 8.4 in CI requires spinning up a separate Zookeeper instance so we can upload the solr configs with basic auth, so the ConfigSet is "trusted"