### PR TITLE
Remove sdoc to address security issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,6 @@ gem 'jquery-rails'
 gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7.0'
-# bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'blacklight', '~> 6.0'
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,8 +322,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rdoc (4.2.2)
-      json (~> 1.4)
     redis (3.3.5)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
@@ -396,9 +394,6 @@ GEM
       ffi (~> 1.9.6)
       rake
     scrub_rb (1.0.1)
-    sdoc (0.4.1)
-      json (~> 1.7, >= 1.7.7)
-      rdoc (~> 4.0)
     sidekiq (5.2.5)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (>= 1.5.0)
@@ -556,7 +551,6 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   rubyzip (>= 1.2.2)
   sass-rails (~> 5.0)
-  sdoc (~> 0.4.0)
   sidekiq
   simplecov (~> 0.9)
   solargraph
@@ -573,4 +567,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.2.16
+   2.2.19


### PR DESCRIPTION
We aren't using the doc building system it supports, and there is a
security issue in an underlying dependency, so better to remove
it.