### PR TITLE
Fixes sort by year bug

### DIFF
--- a/lib/cicognara/catalogo_item.rb
+++ b/lib/cicognara/catalogo_item.rb
@@ -17,6 +17,17 @@ module Cicognara
       end
       doc[:title_display] = solr_title_display(item_label || n)
       doc['digitized_version_available_facet'] = resolve_avail(doc['digitized_version_available_facet'])
+
+      tei_year = single_tei_year(doc[:tei_date_display] || [])
+      if tei_year != nil
+        # Use the year in the TEI data rather than the one in the MARC data.
+        # These values are usually identical but not always. It makes sense to use store in Solr the
+        # year from the TEI data because that is the value that we _display_ to the user and therefore
+        # we want to make sure Solr sorts by this year (rather than the year in MARC that is not
+        # displayed to the user).
+        doc["pub_date"] = tei_year
+      end
+
       doc
     end
 
@@ -68,6 +79,22 @@ module Cicognara
          title_added_entry_display title_series_display
          contents_display edition_display language_display
          related_name_display dclib_display).each { |f| book.delete(f) }
+    end
+
+    # Extracts a single year from an array of TEI display dates.
+    # Notice that each value in the array is a string with maybe a year somewhere
+    # (e.g. "1891" or "A. 1541,", or "1813 al 1818,") and the code makes its best
+    # effort to extract the earliest possible year.
+    def single_tei_year(tei_date_display)
+      years = tei_date_display.map do |date|
+        year_match = date.match(/\d\d\d\d/)&.to_s
+        if year_match
+          year_match.to_i
+        else
+          nil
+        end
+      end
+      years.compact.sort.first
     end
   end
 end

--- a/spec/cicognara/tei_indexer_spec.rb
+++ b/spec/cicognara/tei_indexer_spec.rb
@@ -24,6 +24,15 @@ describe Cicognara::TEIIndexer do
       expect(@subject.books[0].to_solr).to eq @subject.solr_docs[0]
       expect(@subject.solr_docs[6]).to eq @subject.entries[0].to_solr
     end
+
+    it 'prefers the year in TEI over the year in MARC for catalog items' do
+      # Notice that we evaluate against the same Cigonara ID from MARC and from TEI.
+      marc_record = @subject.solr_docs.find { |x| x['cico_id_t'] == ['2'] }
+      expect(marc_record['pub_date']).to eq [1600]
+
+      catalog_item = @subject.solr_docs.find { |x| x[:cico_s] == '2' }
+      expect(catalog_item['pub_date']).to eq 1584
+    end
   end
 
   describe '#solr_docs' do

--- a/spec/fixtures/cicognara.marc.xml
+++ b/spec/fixtures/cicognara.marc.xml
@@ -5,7 +5,7 @@
     <controlfield tag="001">8524680</controlfield>
     <controlfield tag="005">20160419234839.0</controlfield>
     <controlfield tag="007">he|amu|||bacu</controlfield>
-    <controlfield tag="008">981007s1584    gw c    b     000 0 lat d</controlfield>
+    <controlfield tag="008">981007s1600    gw c    b     000 0 lat d</controlfield>
     <datafield ind1=" " ind2=" " tag="035">
       <subfield code="9">0164-96560</subfield>
     </datafield>

--- a/spec/models/marc_indexer_spec.rb
+++ b/spec/models/marc_indexer_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe MarcIndexer, type: :model do
     expect(@values.first['published_t']).to eq(['Coloniae : Apud Theodorum Baumium ..., Anno 1584.'])
   end
   it 'takes pub_date from 008' do
-    expect(@values.first['pub_date']).to eq([1584])
+    expect(@values.first['pub_date']).to eq([1600])
   end
   it 'does not have the term microform in the 245 field' do
     expect(@values.first['title_display'].first).not_to match(/microform/)


### PR DESCRIPTION
Stores in Solr the publication year from the TEI data (when available) to make sure the order makes sense to the user. This is important because we display the year in the TEI data to the user and this make sure the order is evident to them.

Fixes #439 

We still have the issue that a record might not show a date (because there is none in TEI) but the record will display between records with dates (see record 3455 in the screenshot below). This is happening because we are preserving the publication date in MARC (in this case is 1834). We could always overwrite the publication year with the TEI  data even if that means losing the value that we picked from MARC, I not sure we want to do that but it is an option that will prevent users from getting confused.

![sort_year_newest](https://user-images.githubusercontent.com/568286/148461630-8240ba28-1d4e-4c6e-899d-3a9a7a83542e.png)
