### PR TITLE
Updated to calculate previous/next links

### DIFF
--- a/app/views/pages/catalogo/section_1.0.html
+++ b/app/views/pages/catalogo/section_1.0.html
@@ -413,6 +413,10 @@
 	
 	L. C.
       </section>
+         <a rel="prev" class="btn btn-default btn-sm disabled" href="#">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.1">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.1.html
+++ b/app/views/pages/catalogo/section_1.1.html
@@ -1240,6 +1240,12 @@
 	
 	           
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.0">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.2">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.10.html
+++ b/app/views/pages/catalogo/section_1.10.html
@@ -1371,6 +1371,12 @@
             </ol>
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.9">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.11">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.11.html
+++ b/app/views/pages/catalogo/section_1.11.html
@@ -1078,6 +1078,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.10">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.12">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.12.html
+++ b/app/views/pages/catalogo/section_1.12.html
@@ -556,6 +556,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.11">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.13">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.13.html
+++ b/app/views/pages/catalogo/section_1.13.html
@@ -810,6 +810,12 @@
   
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.12">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.14">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.14.html
+++ b/app/views/pages/catalogo/section_1.14.html
@@ -372,6 +372,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.13">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.15">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.15.html
+++ b/app/views/pages/catalogo/section_1.15.html
@@ -1352,6 +1352,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.14">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.16">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.16.html
+++ b/app/views/pages/catalogo/section_1.16.html
@@ -839,6 +839,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.15">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.17">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.17.html
+++ b/app/views/pages/catalogo/section_1.17.html
@@ -1056,6 +1056,12 @@
 	           <span class="catalogo-pb" id="page_232">232</span>
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.16">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.18">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.18.html
+++ b/app/views/pages/catalogo/section_1.18.html
@@ -2697,6 +2697,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.17">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.19">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.19.html
+++ b/app/views/pages/catalogo/section_1.19.html
@@ -315,6 +315,12 @@
                
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.18">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.20">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.2.html
+++ b/app/views/pages/catalogo/section_1.2.html
@@ -3152,6 +3152,12 @@
 	           </ol>
 	           
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.1">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.3">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.20.html
+++ b/app/views/pages/catalogo/section_1.20.html
@@ -3897,6 +3897,12 @@ septem etc.</a>
 
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.19">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.21">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.21.html
+++ b/app/views/pages/catalogo/section_1.21.html
@@ -2066,6 +2066,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.20">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.22">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.22.html
+++ b/app/views/pages/catalogo/section_1.22.html
@@ -170,6 +170,12 @@
   
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.21">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.23">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.23.html
+++ b/app/views/pages/catalogo/section_1.23.html
@@ -2667,6 +2667,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.22">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.24">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.24.html
+++ b/app/views/pages/catalogo/section_1.24.html
@@ -603,6 +603,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.23">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.25">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.25.html
+++ b/app/views/pages/catalogo/section_1.25.html
@@ -3071,6 +3071,12 @@
   
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.24">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.26">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.26.html
+++ b/app/views/pages/catalogo/section_1.26.html
@@ -873,6 +873,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.25">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.0">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.3.html
+++ b/app/views/pages/catalogo/section_1.3.html
@@ -569,6 +569,12 @@
       
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.2">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.4">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.4.html
+++ b/app/views/pages/catalogo/section_1.4.html
@@ -421,6 +421,12 @@
       
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.3">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.5">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.5.html
+++ b/app/views/pages/catalogo/section_1.5.html
@@ -1480,6 +1480,12 @@
             </ol>
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.4">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.6">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.6.html
+++ b/app/views/pages/catalogo/section_1.6.html
@@ -6445,6 +6445,12 @@
                </li>
             </ol>
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.5">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.7">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.7.html
+++ b/app/views/pages/catalogo/section_1.7.html
@@ -632,6 +632,12 @@
       
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.6">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.8">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.8.html
+++ b/app/views/pages/catalogo/section_1.8.html
@@ -413,6 +413,12 @@
       
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.7">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.9">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_1.9.html
+++ b/app/views/pages/catalogo/section_1.9.html
@@ -1245,6 +1245,12 @@
     
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.8">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.10">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.0.html
+++ b/app/views/pages/catalogo/section_2.0.html
@@ -302,6 +302,12 @@ conosciuto o stimato; e perciò giudico meglio di tacermi e finire coll’augura
 
             
          </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_1.26">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.1">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.1.html
+++ b/app/views/pages/catalogo/section_2.1.html
@@ -610,6 +610,12 @@ monumento della medesima Villa</a>
 
                
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.0">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.2">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.10.html
+++ b/app/views/pages/catalogo/section_2.10.html
@@ -4941,6 +4941,12 @@ della medesima ritrovato</a>
                </li>
                </ol>
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.9">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.11">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.11.html
+++ b/app/views/pages/catalogo/section_2.11.html
@@ -2887,6 +2887,12 @@ tedesco e francese.
 		             </li>
                </ol>
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.10">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.12">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.12.html
+++ b/app/views/pages/catalogo/section_2.12.html
@@ -521,6 +521,12 @@ città d’Italia tanto nei luoghi pubblici che privati, e singolarmente del Mus
                </li>
                </ol>
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.11">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.13">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.13.html
+++ b/app/views/pages/catalogo/section_2.13.html
@@ -3405,6 +3405,12 @@ all’eruditissimo Muratori</a>
                   </ol>
                
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.12">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.14">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.14.html
+++ b/app/views/pages/catalogo/section_2.14.html
@@ -2506,6 +2506,12 @@ in 8.</span>
                   
                
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.13">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.15">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.15.html
+++ b/app/views/pages/catalogo/section_2.15.html
@@ -259,6 +259,12 @@
                </li>
                </ol>
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.14">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.16">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.16.html
+++ b/app/views/pages/catalogo/section_2.16.html
@@ -622,6 +622,12 @@ Lombardia, e parte della Romagna</a>
                </li>
                </ol>
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.15">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.17">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.17.html
+++ b/app/views/pages/catalogo/section_2.17.html
@@ -597,6 +597,12 @@ la formazione d’un catalogo, e rende ragione dei varj motivi che in generale c
 
                
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.16">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.18">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.18.html
+++ b/app/views/pages/catalogo/section_2.18.html
@@ -1289,6 +1289,12 @@ Virgilio ec.</a>
                </ol>
                <span class="catalogo-pb" id="page_329">329</span>
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.17">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.19">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.19.html
+++ b/app/views/pages/catalogo/section_2.19.html
@@ -652,6 +652,10 @@ l’Acropole à Athenes</a>
                </ol>
                
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.18">« Previous</a>
+         <a rel="next" class="btn btn-default btn-sm disabled" href="#">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.2.html
+++ b/app/views/pages/catalogo/section_2.2.html
@@ -795,6 +795,12 @@ esemplare.</div>
                </li>
                </ol>
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.1">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.3">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.3.html
+++ b/app/views/pages/catalogo/section_2.3.html
@@ -1228,6 +1228,12 @@ fig.</span>
 
                
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.2">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.4">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.4.html
+++ b/app/views/pages/catalogo/section_2.4.html
@@ -1278,6 +1278,12 @@ Esemplari legati in mar</div>. der.</span>
                </li>
                </ol>
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.3">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.5">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.5.html
+++ b/app/views/pages/catalogo/section_2.5.html
@@ -5004,6 +5004,12 @@ hujus classis numismata ex variis museis etc.</a>
                </li>
                </ol>
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.4">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.6">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.6.html
+++ b/app/views/pages/catalogo/section_2.6.html
@@ -1016,6 +1016,12 @@ In S. Barbarae Nicomediensis cultu. In inventione S. Crucis</a>
 
                
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.5">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.7">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.7.html
+++ b/app/views/pages/catalogo/section_2.7.html
@@ -2618,6 +2618,12 @@ scoperte, discorso</a>
 
                
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.6">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.8">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.8.html
+++ b/app/views/pages/catalogo/section_2.8.html
@@ -1685,6 +1685,12 @@ ma presso che tutte di un certo Fabbri e da posporsi a quelle pubblicate avanti 
                </li>
                </ol>
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.7">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.9">Next »</a>
       </div>
    </div>
 </div>

--- a/app/views/pages/catalogo/section_2.9.html
+++ b/app/views/pages/catalogo/section_2.9.html
@@ -1351,6 +1351,12 @@ colle rispettive illustrazioni contiene il secondo volume.</div>
                <span class="catalogo-pb" id="page_166">166</span>
                
             </section>
+         <a rel="prev"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.8">« Previous</a>
+         <a rel="next"
+            class="btn btn-default btn-sm"
+            href="/catalogo/section_2.10">Next »</a>
       </div>
    </div>
 </div>

--- a/lib/xsl/partials-section.xsl
+++ b/lib/xsl/partials-section.xsl
@@ -78,30 +78,25 @@
                         See https://stackoverflow.com/a/11680802/446681 for the weird [1] syntax.
                          -->
                         <xsl:choose>
-                            <xsl:when test="current()/preceding-sibling::*[@type='section' and @n!='']">
-                                <xsl:variable name="prev_section" select="(current()/preceding-sibling::*[@type='section'])/@n" />
-                                <a rel="prev" class="btn btn-default btn-sm" href="/{$url_path_prefix}catalogo/section_{$prev_section}">« Previous</a>
-                            </xsl:when>
-                            <xsl:when test="current()/preceding::*[@type='section' and @n!=''][1]">
-                                <xsl:variable name="prev_section" select="(current()/preceding::*[@type='section'][1])/@n" />
+                            <xsl:when test="current()/preceding::*[(@type='section' or @type = 'preface') and @n!=''][1]">
+                                <xsl:variable name="prev_section" select="(current()/preceding::*[(@type='section' or @type = 'preface') and @n!=''][1])/@n" />
                                 <a rel="prev" class="btn btn-default btn-sm" href="/{$url_path_prefix}catalogo/section_{$prev_section}">« Previous</a>
                             </xsl:when>
                             <xsl:otherwise>
                                 <a rel="prev" class="btn btn-default btn-sm disabled" href="#">« Previous</a>
                             </xsl:otherwise>
                         </xsl:choose>
-                        <span> </span>
+
                         <!-- Next button -->
                         <xsl:choose>
-                            <xsl:when test="empty(current()/following::*[@type='section'])">
+                            <xsl:when test="empty(current()/following::*[(@type='section' or @type = 'preface') and @n!=''])">
                                 <a rel="next" class="btn btn-default btn-sm disabled" href="#">Next »</a>
                             </xsl:when>
                             <xsl:otherwise>
-                                <xsl:variable name="next_section" select="(current()/following::*[@type='section'])/@n" />
+                                <xsl:variable name="next_section" select="(current()/following::*[(@type='section' or @type = 'preface') and @n!=''])/@n" />
                                 <a rel="next" class="btn btn-default btn-sm" href="/{$url_path_prefix}catalogo/section_{$next_section}">Next »</a>
                             </xsl:otherwise>
                         </xsl:choose>
-
                     </div>
                 </div>
             </div>

--- a/lib/xsl/partials-section.xsl
+++ b/lib/xsl/partials-section.xsl
@@ -71,6 +71,37 @@
                         <section class="catalogo-section" id="{@n}">
                             <xsl:apply-templates/>
                         </section>
+
+                        <!-- Previous button
+                        Get the previous sibling (when previous is in the same section),
+                        or the last sibling of the previous sibling (when previous is in another section)
+                        See https://stackoverflow.com/a/11680802/446681 for the weird [1] syntax.
+                         -->
+                        <xsl:choose>
+                            <xsl:when test="current()/preceding-sibling::*[@type='section' and @n!='']">
+                                <xsl:variable name="prev_section" select="(current()/preceding-sibling::*[@type='section'])/@n" />
+                                <a rel="prev" class="btn btn-default btn-sm" href="/{$url_path_prefix}catalogo/section_{$prev_section}">« Previous</a>
+                            </xsl:when>
+                            <xsl:when test="current()/preceding::*[@type='section' and @n!=''][1]">
+                                <xsl:variable name="prev_section" select="(current()/preceding::*[@type='section'][1])/@n" />
+                                <a rel="prev" class="btn btn-default btn-sm" href="/{$url_path_prefix}catalogo/section_{$prev_section}">« Previous</a>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <a rel="prev" class="btn btn-default btn-sm disabled" href="#">« Previous</a>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                        <span> </span>
+                        <!-- Next button -->
+                        <xsl:choose>
+                            <xsl:when test="empty(current()/following::*[@type='section'])">
+                                <a rel="next" class="btn btn-default btn-sm disabled" href="#">Next »</a>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:variable name="next_section" select="(current()/following::*[@type='section'])/@n" />
+                                <a rel="next" class="btn btn-default btn-sm" href="/{$url_path_prefix}catalogo/section_{$next_section}">Next »</a>
+                            </xsl:otherwise>
+                        </xsl:choose>
+
                     </div>
                 </div>
             </div>
@@ -163,13 +194,13 @@
             <xsl:apply-templates/>
         </span>
     </xsl:template>
-    
+
     <xsl:template match="tei:extent">
         <span class="catalogo-extent">
             <xsl:apply-templates/>
         </span>
     </xsl:template>
-    
+
     <xsl:template match="tei:p">
         <p>
             <xsl:apply-templates/>


### PR DESCRIPTION
Adds previous and next buttons at the bottom of the section partials. The code handles prev/next across sections (e.g. from section 1.26 to section 2.0)

Fixes #447 

PR Includes the 40+ generated partials.

![prev-next](https://user-images.githubusercontent.com/568286/148847920-45f948c1-6b64-4ad2-94be-99c600c0bd67.png)

