### PR TITLE
Issue 443 subject search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -124,7 +124,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'note_display', label: 'Note(s)', helper_method: :html_safe
     config.add_show_field 'title_added_entry_display', label: 'Added entry title(s)'
     config.add_show_field 'related_name_display', label: 'Related name(s)', link_to_search: :name_facet
-    config.add_show_field 'subject_t', label: 'Subject', link_to_search: :subject_facet
+    config.add_show_field 'subject_topic_facet', label: 'Subject', link_to_search: :subject_topic_facet
     config.add_show_field 'place_display', label: 'Place of publications'
     config.add_show_field 'description_display', label: 'Description'
     config.add_show_field 'title_series_display', label: 'Series'

--- a/app/helpers/show_helper.rb
+++ b/app/helpers/show_helper.rb
@@ -2,9 +2,17 @@
 
 # stick version metadata into a solr document
 module ShowHelper
-  def version_show_document(version)
+  # Creates a SolrDocument object out of a Version ActiveRecord object.
+  def version_show_document(version, book_doc = nil)
     metadata = version.imported_metadata || {}
-    SolrDocument.new(metadata.merge(blacklight_required_fields))
+    version_doc = SolrDocument.new(metadata.merge(blacklight_required_fields))
+    if book_doc['subject_topic_facet']
+      # Take the "subject_topic_facet" info from the book document since
+      # the version document only has the "subject_t" field that is not
+      # suitable for faceting,
+      version_doc['subject_topic_facet'] = book_doc['subject_topic_facet']
+    end
+    version_doc
   end
 
   def blacklight_required_fields

--- a/app/views/catalog/_version_tabs_default.html.erb
+++ b/app/views/catalog/_version_tabs_default.html.erb
@@ -8,7 +8,6 @@
         <%= render partial: 'linked_books_default', locals: { book: version_show_document(version, book), document_id: "version_#{version.id}", hide: (i > 0) } %>
       <% end %>
     <% else %>
-      <h2>No book record</h2>
       <%# If there's no book record, just show the metadata from the marc %>
       <%= render partial: 'linked_books_default', locals: { book: book, document_id: "book_#{book['id']}", hide: false } %>
     <% end %>

--- a/app/views/catalog/_version_tabs_default.html.erb
+++ b/app/views/catalog/_version_tabs_default.html.erb
@@ -5,9 +5,10 @@
       <%= render partial: 'linked_books_default', locals: { book: book, document_id: "book_#{book['id']}", hide: versions.present? } %>
 
       <% versions.each_with_index do |version, i| %>
-        <%= render partial: 'linked_books_default', locals: { book: version_show_document(version), document_id: "version_#{version.id}", hide: (i > 0) } %>
+        <%= render partial: 'linked_books_default', locals: { book: version_show_document(version, book), document_id: "version_#{version.id}", hide: (i > 0) } %>
       <% end %>
     <% else %>
+      <h2>No book record</h2>
       <%# If there's no book record, just show the metadata from the marc %>
       <%= render partial: 'linked_books_default', locals: { book: book, document_id: "book_#{book['id']}", hide: false } %>
     <% end %>

--- a/spec/features/view_spec.rb
+++ b/spec/features/view_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'entry views', type: :feature do
   it 'displays links to controlled terms' do
     visit '/catalog/15'
     expect(page).to have_link 'Brontius, Nicolaus, 16th century', href: '/catalog?f%5Bname_facet%5D%5B%5D=Brontius%2C+Nicolaus%2C+16th+century'
-    expect(page).to have_link 'Humanism—Early works to 1800', href: '/catalog?f%5Bsubject_facet%5D%5B%5D=Humanism%E2%80%94Early+works+to+1800'
+    expect(page).to have_link 'Humanism', href: '/catalog?f%5Bsubject_topic_facet%5D%5B%5D=Humanism'
   end
 
   it 'displays metadata' do


### PR DESCRIPTION
Switches the subject field used for searching when clicking on a Show page subject. We were using a text tokenized field (`subject_t`) in the Show page and but we use a string field (`subject_topic_facet`) in the Search page. 

Field `subject_topic_facet` field is a String field and that's the correct field to use for faceting. Faceting on tokenized fields like `subject_t` is a no-no.

We also store slightly different values in `subject_t` vs `subject_topic_facet`, it looks like we consolidate term variations into a single root subject. For example we store "Medicine—Early works to 1800" in the `subject_t` field vs faceted as just "Medicine" in the `subject_topic_facet`. The code accounts for this.

This addresses the failed subject searches in #443, but there are other fields to fix so it does not close that issue.

Below is an example of a Search result by subject and how they look (and link) in the Show page:

![search_subject](https://user-images.githubusercontent.com/568286/149410035-1dd76cf9-96c1-482c-b35f-8e83fbf0cef2.png)

![show_subject](https://user-images.githubusercontent.com/568286/149410061-340cb139-411c-4c7c-ae9f-f7ec1021f21f.png)

