### PR TITLE
Force rake tasks to run sequentially

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,7 +22,5 @@ set :job_template, "bash -l -c 'export PATH=\"/usr/local/bin/:$PATH\" && :job'"
 job_type :logging_rake, 'cd :path && :environment_variable=:environment bundle exec rake :task :output'
 
 every :tuesday, at: '11pm', roles: [:db] do
-  rake 'getty:import'
-  rake 'tei:catalogo:update'
-  rake 'tei:index'
+  rake 'tei:reindex'
 end

--- a/lib/tasks/getty.rake
+++ b/lib/tasks/getty.rake
@@ -1,11 +1,11 @@
 namespace :getty do
   desc 'Import resources from Getty'
   task import: :environment do
-    Rails.logger.info 'Beginning Import'
+    Rails.logger.info 'Beginning getty:import'
     GettyParser.new.import!
     Rails.logger.info 'Committing Solr'
     Blacklight.default_index.connection.commit
-    Rails.logger.info 'Import Finished'
+    Rails.logger.info 'Import finished getty:import'
   end
 
   desc 'Import subset of getty resources that matches tei fixtures'


### PR DESCRIPTION
Force rake tasks to run sequentially when scheduled and added some logging.

Fixes #539 for real

I had to create a new rake task to execute the steps sequentially since `whenever` didn't allowed me to call more than one rake task on the definition.